### PR TITLE
Improve builds runner

### DIFF
--- a/azure-devops/azure-devops-api.ps1
+++ b/azure-devops/azure-devops-api.ps1
@@ -92,7 +92,7 @@ function Get-AzureDevOpsApi {
         [string] $ProjectName,
         [string] $AccessToken,
         [UInt32] $RetryCount = 3,
-        [UInt32] $RetryIntervalSec = 30
+        [UInt32] $RetryIntervalSec = 60
     )
 
     return [AzureDevOpsApi]::New($TeamFoundationCollectionUri, $ProjectName, $AccessToken, $RetryCount, $RetryIntervalSec)

--- a/azure-devops/azure-devops-api.ps1
+++ b/azure-devops/azure-devops-api.ps1
@@ -3,8 +3,8 @@ class AzureDevOpsApi
     [string] $BaseUrl
     [string] $RepoOwner
     [object] $AuthHeader
-    [UInt32] $RetryCount = 0
-    [UInt32] $RetryIntervalSec = 30
+    [UInt32] $RetryCount
+    [UInt32] $RetryIntervalSec
 
     AzureDevOpsApi(
         [string] $TeamFoundationCollectionUri,
@@ -15,13 +15,8 @@ class AzureDevOpsApi
     ) {
         $this.BaseUrl = $this.BuildBaseUrl($TeamFoundationCollectionUri, $ProjectName)
         $this.AuthHeader = $this.BuildAuth($AccessToken)
-        
-        if ($RetryCount -gt 0) {
-            $this.RetryCount = $RetryCount
-        }
-        if ($RetryIntervalSec -gt 0) {
-            $this.RetryIntervalSec = $RetryIntervalSec
-        }
+        $this.RetryCount = $RetryCount
+        $this.RetryIntervalSec = $RetryIntervalSec
     }
 
     [object] hidden BuildAuth([string]$AccessToken) {
@@ -96,8 +91,8 @@ function Get-AzureDevOpsApi {
         [string] $TeamFoundationCollectionUri,
         [string] $ProjectName,
         [string] $AccessToken,
-        [UInt32] $RetryCount,
-        [UInt32] $RetryIntervalSec
+        [UInt32] $RetryCount = 3,
+        [UInt32] $RetryIntervalSec = 30
     )
 
     return [AzureDevOpsApi]::New($TeamFoundationCollectionUri, $ProjectName, $AccessToken, $RetryCount, $RetryIntervalSec)

--- a/azure-devops/azure-devops-api.ps1
+++ b/azure-devops/azure-devops-api.ps1
@@ -3,14 +3,25 @@ class AzureDevOpsApi
     [string] $BaseUrl
     [string] $RepoOwner
     [object] $AuthHeader
+    [UInt32] $RetryCount = 0
+    [UInt32] $RetryIntervalSec = 30
 
     AzureDevOpsApi(
         [string] $TeamFoundationCollectionUri,
         [string] $ProjectName,
-        [string] $AccessToken
+        [string] $AccessToken,
+        [UInt32] $RetryCount,
+        [UInt32] $RetryIntervalSec
     ) {
         $this.BaseUrl = $this.BuildBaseUrl($TeamFoundationCollectionUri, $ProjectName)
         $this.AuthHeader = $this.BuildAuth($AccessToken)
+        
+        if ($RetryCount -gt 0) {
+            $this.RetryCount = $RetryCount
+        }
+        if ($RetryIntervalSec -gt 0) {
+            $this.RetryIntervalSec = $RetryIntervalSec
+        }
     }
 
     [object] hidden BuildAuth([string]$AccessToken) {
@@ -73,17 +84,21 @@ class AzureDevOpsApi
             $params.Body = $Body
         }
 
+        $params.RetryIntervalSec = $this.RetryIntervalSec
+        $params.MaximumRetryCount = $this.RetryCount
+
         return Invoke-RestMethod @params
     }
-
 }
 
 function Get-AzureDevOpsApi {
     param (
         [string] $TeamFoundationCollectionUri,
         [string] $ProjectName,
-        [string] $AccessToken
+        [string] $AccessToken,
+        [UInt32] $RetryCount,
+        [UInt32] $RetryIntervalSec
     )
 
-    return [AzureDevOpsApi]::New($TeamFoundationCollectionUri, $ProjectName, $AccessToken)
+    return [AzureDevOpsApi]::New($TeamFoundationCollectionUri, $ProjectName, $AccessToken, $RetryCount, $RetryIntervalSec)
 }

--- a/azure-devops/run-ci-builds.ps1
+++ b/azure-devops/run-ci-builds.ps1
@@ -3,31 +3,80 @@ param (
     [Parameter(Mandatory)] [string] $AzureDevOpsProjectName,
     [Parameter(Mandatory)] [string] $AzureDevOpsAccessToken,
     [Parameter(Mandatory)] [string] $SourceBranch,
-    [Parameter(Mandatory)] [string] $ToolVersions,
     [Parameter(Mandatory)] [UInt32] $DefinitionId,
-    [string] $SourceVersion
+    [Parameter(Mandatory)] [string] $SourceVersion,
+    [Parameter(Mandatory)] [string] $ManifestLink,
+    [Parameter(Mandatory)] [bool] $WaitForBuilds,
+    [string] $ToolVersions,
+    [UInt32] $RetryIntervalSec = 30,
+    [UInt32] $RetryCount = 20
 )
 
 Import-Module (Join-Path $PSScriptRoot "azure-devops-api.ps1")
 Import-Module (Join-Path $PSScriptRoot "build-info.ps1")
 
+function Get-ToolVersions {
+    param (
+        [Parameter(Mandatory)] [string] $ManifestLink,
+        [Parameter(Mandatory)] [UInt32] $RetryIntervalSec,
+        [Parameter(Mandatory)] [UInt32] $Retries,
+        [string] $ToolVersions
+    )
+    
+    [string[]] $versionsList = @()
+    if ($ToolVersions){
+        $versionsList = $ToolVersions.Split(',')
+    } else {
+        Write-Host "Get the list of releases from $ManifestLink"
+        $releases = Invoke-RestMethod $ManifestLink -MaximumRetryCount $Retries -RetryIntervalSec $RetryIntervalSec
+        $releases | ForEach-Object { $versionsList += $_.version }
+    }
+
+    return $versionsList
+}
+
 function Queue-Builds {
     param (
         [Parameter(Mandatory)] [AzureDevOpsApi] $AzureDevOpsApi,
-        [Parameter(Mandatory)] [string] $ToolVersions,
+        [Parameter(Mandatory)] [string[]] $ToolVersions,
         [Parameter(Mandatory)] [string] $SourceBranch,
         [Parameter(Mandatory)] [string] $SourceVersion,
-        [Parameter(Mandatory)] [string] $DefinitionId
+        [Parameter(Mandatory)] [UInt32] $DefinitionId,
+        [Parameter(Mandatory)] [UInt32] $RetryIntervalSec,
+        [Parameter(Mandatory)] [UInt32] $Retries
     )
 
     [BuildInfo[]]$queuedBuilds = @()
 
-    $ToolVersions.Split(',') | ForEach-Object { 
+    $ToolVersions | ForEach-Object { 
         $version = $_.Trim()
-        Write-Host "Queue build for $version..."
-        $queuedBuild = $AzureDevOpsApi.QueueBuild($version, $SourceBranch, $SourceVersion, $DefinitionId)
-        $buildInfo = Get-BuildInfo -AzureDevOpsApi $AzureDevOpsApi -Build $queuedBuild
-        Write-Host "Queued build: $($buildInfo.Link)"
+        
+        while ($Retries -gt 0)
+        {
+            try
+            {
+                Write-Host "Queue build for $version..."
+                $queuedBuild = $AzureDevOpsApi.QueueBuild($version, $SourceBranch, $SourceVersion, $DefinitionId)
+                $buildInfo = Get-BuildInfo -AzureDevOpsApi $AzureDevOpsApi -Build $queuedBuild
+                Write-Host "Queued build: $($buildInfo.Link)"
+                break
+            }
+            catch
+            {
+                Write-Host "There is an error during build starting:`n $_"
+                $Retries--
+            
+                if ($Retries -eq 0)
+                {
+                    Write-Host "Build can't be queued, please try later"
+                    exit 1
+                }
+            
+                Write-Host "Waiting 30 seconds before retrying. Retries left: $Retries"
+                Start-Sleep -Seconds $RetryIntervalSec
+            }
+        }
+        
         $queuedBuilds += $buildInfo
     }
 
@@ -36,10 +85,9 @@ function Queue-Builds {
 
 function Wait-Builds {
     param (
-        [Parameter(Mandatory)] [BuildInfo[]] $Builds
+        [Parameter(Mandatory)] [BuildInfo[]] $Builds,
+        [Parameter(Mandatory)] [UInt32] $RetryIntervalSec
     )
-
-    $timeoutBetweenRefreshSec = 30
     
     do {
         # If build is still running - refresh its status
@@ -55,7 +103,7 @@ function Wait-Builds {
     
         $runningBuildsCount = ($builds | Where-Object { !$_.IsFinished() }).Length
 
-        Start-Sleep -Seconds $timeoutBetweenRefreshSec
+        Start-Sleep -Seconds $RetryIntervalSec
     } while($runningBuildsCount -gt 0)
 }
 
@@ -64,7 +112,7 @@ function Make-BuildsOutput {
         [Parameter(Mandatory)] [BuildInfo[]] $Builds
     )
 
-    Write-Host "Builds info:"
+    Write-Host "`nBuilds info:"
     $builds | Format-Table -AutoSize -Property Name,Id,Status,Result,Link | Out-String -Width 10000
 
     # Return exit code based on status of builds
@@ -74,7 +122,7 @@ function Make-BuildsOutput {
         $failedBuilds | ForEach-Object -Process { Write-Host "##vso[task.logissue type=error;]Name: $($_.Name); Link: $($_.Link)" }
         Write-Host "##vso[task.complete result=Failed]"
     } else {
-        Write-host "##[section] All builds have been passed successfully"
+        Write-host "##[section]All builds have been passed successfully"
     }
 }
 
@@ -82,13 +130,22 @@ $azureDevOpsApi = Get-AzureDevOpsApi -TeamFoundationCollectionUri $TeamFoundatio
                                      -ProjectName $AzureDevOpsProjectName `
                                      -AccessToken $AzureDevOpsAccessToken
 
+$toolVersionsList = Get-ToolVersions -ManifestLink $ManifestLink `
+                                     -RetryIntervalSec $RetryIntervalSec `
+                                     -Retries $RetryCount `
+                                     -ToolVersions $ToolVersions
+
 $queuedBuilds = Queue-Builds -AzureDevOpsApi $azureDevOpsApi `
-                             -ToolVersions $ToolVersions `
+                             -ToolVersions $toolVersionsList `
                              -SourceBranch $SourceBranch `
                              -SourceVersion $SourceVersion `
-                             -DefinitionId $DefinitionId
+                             -DefinitionId $DefinitionId `
+                             -RetryIntervalSec $RetryIntervalSec `
+                             -Retries $RetryCount
 
-Write-Host "Waiting results of builds ..."
-Wait-Builds -Builds $queuedBuilds
-
-Make-BuildsOutput -Builds $queuedBuilds
+if ($WaitForBuilds) {
+    Write-Host "`nWaiting results of builds ..."
+    Wait-Builds -Builds $queuedBuilds -RetryIntervalSec $RetryIntervalSec
+    
+    Make-BuildsOutput -Builds $queuedBuilds
+}

--- a/azure-devops/run-ci-builds.ps1
+++ b/azure-devops/run-ci-builds.ps1
@@ -8,7 +8,7 @@ param (
     [Parameter(Mandatory)] [string] $ManifestLink,
     [Parameter(Mandatory)] [bool] $WaitForBuilds,
     [string] $ToolVersions,
-    [UInt32] $RetryIntervalSec = 30,
+    [UInt32] $RetryIntervalSec = 60,
     [UInt32] $RetryCount = 3
 )
 

--- a/azure-devops/run-ci-builds.ps1
+++ b/azure-devops/run-ci-builds.ps1
@@ -24,12 +24,12 @@ function Get-ToolVersions {
     )
     
     [string[]] $versionsList = @()
-    if ($ToolVersions){
+    if ($ToolVersions) {
         $versionsList = $ToolVersions.Split(',')
     } else {
         Write-Host "Get the list of releases from $ManifestLink"
         $releases = Invoke-RestMethod $ManifestLink -MaximumRetryCount $Retries -RetryIntervalSec $RetryIntervalSec
-        $releases | ForEach-Object { $versionsList += $_.version }
+        $versionsList = $releases.version
     }
 
     return $versionsList

--- a/azure-devops/run-ci-builds.ps1
+++ b/azure-devops/run-ci-builds.ps1
@@ -9,7 +9,7 @@ param (
     [Parameter(Mandatory)] [bool] $WaitForBuilds,
     [string] $ToolVersions,
     [UInt32] $RetryIntervalSec = 30,
-    [UInt32] $RetryCount = 20
+    [UInt32] $RetryCount = 3
 )
 
 Import-Module (Join-Path $PSScriptRoot "azure-devops-api.ps1")


### PR DESCRIPTION
In scope of this PR we improve builds runner. We've added 
- retry logic for builds queuing;
- `WAIT_FOR_BUILDS` flag in order to manage waiting of queued builds results;
- opportunity to specify link to the `versions-manifest.json` instead of tool versions list in order to rebuild all uploaded versions

![image](https://user-images.githubusercontent.com/46996400/84644666-22ffa580-af08-11ea-8ed1-d864b2088e65.png)