### PR TITLE
Implement script to validate manifest files

### DIFF
--- a/packages-generation/manifest-validator.ps1
+++ b/packages-generation/manifest-validator.ps1
@@ -16,6 +16,7 @@ function Publish-Error {
     )
     Write-Host "##vso[task.logissue type=error]ERROR: $ErrorDescription."
     Write-Host "##vso[task.logissue type=error]    $Exception"
+    Write-Host "##vso[task.complete result=Failed;]"
 }
 
 function Test-DownloadUrl {

--- a/packages-generation/manifest-validator.ps1
+++ b/packages-generation/manifest-validator.ps1
@@ -21,7 +21,6 @@ function Publish-Error {
 
 function Test-DownloadUrl {
     param([string] $DownloadUrl)
-    $DownloadUrl = $DownloadUrl + "w"
     $request = [System.Net.WebRequest]::Create($DownloadUrl)
     if ($AccessToken) {
         $request.Headers.Add("Authorization", $authorizationHeaderValue)

--- a/packages-generation/manifest-validator.ps1
+++ b/packages-generation/manifest-validator.ps1
@@ -1,0 +1,62 @@
+param (
+    [Parameter(Mandatory)][string] $ManifestUrl,
+    [string] $AccessToken
+)
+
+$authorizationHeaderValue = "Basic $AccessToken"
+$webRequestHeaders = @{}
+if ($AccessToken) {
+    $webRequestHeaders.Add("Authorization", $authorizationHeaderValue)
+}
+
+function Publish-Error {
+    param(
+        [string] $ErrorDescription,
+        [object] $Exception
+    )
+    Write-Host "##vso[task.logissue type=error]ERROR: $ErrorDescription."
+    Write-Host "##vso[task.logissue type=error]    $Exception"
+}
+
+function Test-DownloadUrl {
+    param([string] $DownloadUrl)
+    $request = [System.Net.WebRequest]::Create($DownloadUrl)
+    if ($AccessToken) {
+        $request.Headers.Add("Authorization", $authorizationHeaderValue)
+    }
+    try {
+        $response = $request.GetResponse()
+        return ([int]$response.StatusCode -eq 200)
+    } catch {
+        return $false
+    }
+}
+
+Write-Host "Downloading manifest json from '$ManifestUrl'..."
+try {
+    $manifestResponse = Invoke-WebRequest -Method Get -Uri $ManifestUrl -Headers $webRequestHeaders
+} catch {
+    Publish-Error "Unable to download manifest json from '$ManifestUrl'" $_
+    exit 1
+}
+
+Write-Host "Parsing manifest json content from '$ManifestUrl'..."
+try {
+    $manifestJson = $manifestResponse.Content | ConvertFrom-Json
+} catch {
+    Publish-Error "Unable to parse manifest json content '$ManifestUrl'" $_
+    exit 1
+}
+
+$versionsList = $manifestJson.version
+Write-Host "Found versions: $($versionsList -join ', ')"
+
+$manifestJson | ForEach-Object {
+    Write-Host "Validating version '$($_.version)'..."
+    $_.files | ForEach-Object {
+        Write-Host "    Validating '$($_.download_url)'..."
+        if (-not (Test-DownloadUrl $_.download_url)) {
+            Publish-Error "Url '$($_.download_url)' is invalid"
+        }
+    }
+}

--- a/packages-generation/manifest-validator.ps1
+++ b/packages-generation/manifest-validator.ps1
@@ -20,6 +20,7 @@ function Publish-Error {
 
 function Test-DownloadUrl {
     param([string] $DownloadUrl)
+    $DownloadUrl = $DownloadUrl + "w"
     $request = [System.Net.WebRequest]::Create($DownloadUrl)
     if ($AccessToken) {
         $request.Headers.Add("Authorization", $authorizationHeaderValue)


### PR DESCRIPTION
Manifest files are used by image-generation and setup tasks. It is important to keep them valid because if any release is removed, manifest file will be invalid and image-generation / setup tasks will fail.

This PR brings pretty simple script that validates manifest file and check all download links inside it.
Link to definition: https://dev.azure.com/github/virtual-environments/_build/results?buildId=72707&view=results
