### PR TITLE
Add script to get new available tool versions

### DIFF
--- a/check-new-tool-versions.ps1
+++ b/check-new-tool-versions.ps1
@@ -1,0 +1,127 @@
+<#
+.SYNOPSIS
+Check and return list of new available tool versions
+#>
+
+param (
+    [Parameter(Mandatory)] [string] $DistURL,
+    [Parameter(Mandatory)] [string] $ManifestLink,
+    [string] $VersionFilterToInclude,
+    [string] $VersionFilterToExclude,
+    [UInt32] $RetryIntervalSec = 60,
+    [UInt32] $RetryCount = 3
+)
+
+function Get-VersionsByUrl {
+    param (
+        [Parameter(Mandatory)] [string] $ToolPackagesUrl,
+        [Parameter(Mandatory)] [UInt32] $RetryIntervalSec,
+        [Parameter(Mandatory)] [UInt32] $RetryCount
+    )
+
+    $packages = Invoke-RestMethod $ToolPackagesUrl -MaximumRetryCount $RetryCount -RetryIntervalSec $RetryIntervalSec
+    return $packages.version
+}
+
+function Format-Versions {
+    param (
+        [Parameter(Mandatory)] [string[]] $Versions
+    )
+
+    [Version[]] $formattedVersions = @()
+    
+    foreach($version in $Versions) { 
+        $substredVersion = $null
+        
+        # We cut a string from index of first digit because initially it has invalid format (v14.4.0 or go1.14.4)
+        if ($version -match '(?<number>\d)') {
+            $firstDigitIndex = $version.indexof($Matches.number)
+            $substredVersion = $version.substring($firstDigitIndex)
+        } else {
+            Write-Host "Invalid version format - $version"
+            exit 1
+        }
+        
+        # We filter versions to exclude unstable (for example: "go1.15beta1")
+        # Valid version format: x.x or x.x.x
+        if ($substredVersion -notmatch '^\d+\.+\d+\.*\d*$') {
+            continue
+        }
+
+        if ($substredVersion.Split(".").Length -lt 3) {
+            $formattedVersions += "$substredVersion.0"
+        } else {
+            $formattedVersions += $substredVersion
+        }  
+    }
+
+    return $formattedVersions
+}
+
+function Filter-Versions {
+    param (
+        [Parameter(Mandatory)] [string[]] $Versions,
+        [Parameter(Mandatory)] [string] $VersionFilter,
+        [Parameter(Mandatory)] [bool] $IncludeVersions
+    )
+
+    $versionFilters = $VersionFilter.Split(',')
+    [Version[]] $filteredVersions = @()
+
+    foreach($filter in $versionFilters) {
+        if ($IncludeVersions) {
+            $filteredVersions += $Versions | Where-Object { $_ -like $filter }
+        } else {
+            $filteredVersions += $Versions | Where-Object { $_ -notlike $filter }
+        }
+    }
+
+    return $filteredVersions
+}
+
+function Get-VersionsToBuild {
+    param (
+        [Parameter(Mandatory)] [string[]] $VersionsFromManifest,
+        [Parameter(Mandatory)] [string[]] $VersionsFromDist
+    )
+
+    [System.Collections.ArrayList]$versionsToBuid = $VersionsFromDist
+    $VersionsFromManifest | ForEach-Object { $versionsToBuid.Remove($_) }
+
+    return $versionsToBuid
+}
+
+Write-Host "Get the packages list from $DistURL"
+$versionsFromDist = Get-VersionsByUrl -ToolPackagesUrl $DistURL `
+                                      -RetryIntervalSec $RetryIntervalSec `
+                                      -RetryCount $RetryCount
+
+Write-Host "Get the packages list from $ManifestLink"
+[Version[]] $versionsFromManifest = Get-VersionsByUrl -ToolPackagesUrl $ManifestLink `
+                                                      -RetryIntervalSec $RetryIntervalSec `
+                                                      -RetryCount $RetryCount
+
+[Version[]] $formattedVersions = Format-Versions -Versions $versionsFromDist
+
+if (-not ([string]::IsNullOrEmpty($VersionFilterToInclude))) {
+    $formattedVersions = Filter-Versions -Versions $formattedVersions `
+                                         -VersionFilter $VersionFilterToInclude `
+                                         -IncludeVersions $true
+}
+
+if (-not ([string]::IsNullOrEmpty($VersionFilterToExclude))) {
+    $formattedVersions = Filter-Versions -Versions $formattedVersions `
+                                         -VersionFilter $VersionFilterToExclude `
+                                         -IncludeVersions $false
+}
+
+$versionsToBuild = Get-VersionsToBuild -VersionsFromManifest $versionsFromManifest `
+                                       -VersionsFromDist $formattedVersions
+
+if ([string]::IsNullOrEmpty($versionsToBuild)) {
+    Write-Host "There isn't versions to build"
+    return $null
+} else {
+    Write-Host "The following versions are available to build:`n$versionsToBuild"
+    return "$versionsToBuild"
+}

--- a/get-new-tool-versions/get-new-tool-versions.Tests.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.Tests.ps1
@@ -2,6 +2,21 @@
 
 Import-Module (Join-Path $PSScriptRoot "helpers.psm1") -Force
   
+Describe "Validate-FiltersFormat" {
+    It "Filter with word" {
+        { Validate-FiltersFormat -Filters @("1two.2") } | Should -Throw "Invalid filter format"
+    }
+
+    It "Filter with non-word character" {
+        { Validate-FiltersFormat -Filters @("1,.2") } | Should -Throw "Invalid filter format"
+    }
+
+    It "Valid filters" {
+        { Validate-FiltersFormat -Filters @("*", "1", "1.*", "1.2", "1.2.*") } | Should -Not -Throw "Invalid filter format"
+    }
+
+}
+
 Describe "Format-Versions" {
     It "Clean versions" {
         $actualOutput = Format-Versions -Versions @("14.2.0", "1.14.0")
@@ -34,13 +49,13 @@ Describe "Format-Versions" {
     }
 }
 
-Describe "Filter-Versions" {
+Describe "Select-VersionsByFilter" {
     $inputVersions = @("8.2.1", "9.3.3", "10.0.2", "10.0.3", "10.5.6", "12.4.3", "12.5.1", "14.2.0")
 
     It "Include filter only" {
         $includeFilters = @("8.*", "14.*")
         $excludeFilters = @()
-        $actualOutput = Filter-Versions -Versions $inputVersions -IncludeFilters $includeFilters -ExcludeFilters $excludeFilters
+        $actualOutput = Select-VersionsByFilter -Versions $inputVersions -IncludeFilters $includeFilters -ExcludeFilters $excludeFilters
         $expectedOutput = @("8.2.1", "14.2.0")
         $actualOutput | Should -Be $expectedOutput
     }
@@ -48,7 +63,7 @@ Describe "Filter-Versions" {
     It "Include and exclude filters" {
         $includeFilters = @("10.*", "12.*")
         $excludeFilters = @("10.0.*", "12.4.3")
-        $actualOutput = Filter-Versions -Versions $inputVersions -IncludeFilters $includeFilters -ExcludeFilters $excludeFilters
+        $actualOutput = Select-VersionsByFilter -Versions $inputVersions -IncludeFilters $includeFilters -ExcludeFilters $excludeFilters
         $expectedOutput = @("10.5.6", "12.5.1")
         $actualOutput | Should -Be $expectedOutput
     }
@@ -56,13 +71,13 @@ Describe "Filter-Versions" {
     It "Exclude filter only" {
         $includeFilters = @()
         $excludeFilters = @("10.*", "12.*")
-        $actualOutput = Filter-Versions -Versions $inputVersions -IncludeFilters $includeFilters -ExcludeFilters $excludeFilters
+        $actualOutput = Select-VersionsByFilter -Versions $inputVersions -IncludeFilters $includeFilters -ExcludeFilters $excludeFilters
         $expectedOutput = @("8.2.1", "9.3.3", "14.2.0")
         $actualOutput | Should -Be $expectedOutput
     }
 
     It "Include and exclude filters are empty" {
-        $actualOutput = Filter-Versions -Versions $inputVersions
+        $actualOutput = Select-VersionsByFilter -Versions $inputVersions
         $expectedOutput = @("8.2.1", "9.3.3", "10.0.2", "10.0.3", "10.5.6", "12.4.3", "12.5.1", "14.2.0")
         $actualOutput | Should -Be $expectedOutput
     }

--- a/get-new-tool-versions/get-new-tool-versions.Tests.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.Tests.ps1
@@ -14,7 +14,6 @@ Describe "Validate-FiltersFormat" {
     It "Valid filters" {
         { Validate-FiltersFormat -Filters @("*", "1", "1.*", "1.2", "1.2.*") } | Should -Not -Throw "Invalid filter format"
     }
-
 }
 
 Describe "Format-Versions" {

--- a/get-new-tool-versions/get-new-tool-versions.Tests.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.Tests.ps1
@@ -27,7 +27,7 @@ Describe "Format-Versions" {
         $actualOutput | Should -Be $expectedOutput
     }
 
-    It "Skip versions with 1 digin" {
+    It "Skip versions with 1 digit" {
         $actualOutput = Format-Versions -Versions @("14", "v2")
         $expectedOutput = @()
         $actualOutput | Should -Be $expectedOutput
@@ -37,27 +37,42 @@ Describe "Format-Versions" {
 Describe "Filter-Versions" {
     $inputVersions = @("8.2.1", "9.3.3", "10.0.2", "10.0.3", "10.5.6", "12.4.3", "12.5.1", "14.2.0")
 
-    It "Include filter" {
+    It "Include filter only" {
         $includeFilters = @("8.*", "14.*")
-        $actualOutput = Filter-Versions -Versions $inputVersions -IncludeFilters $includeFilters
+        $excludeFilters = @()
+        $actualOutput = Filter-Versions -Versions $inputVersions -IncludeFilters $includeFilters -ExcludeFilters $excludeFilters
         $expectedOutput = @("8.2.1", "14.2.0")
         $actualOutput | Should -Be $expectedOutput
     }
 
-    It "Exclude filter" {
+    It "Include and exclude filters" {
         $includeFilters = @("10.*", "12.*")
         $excludeFilters = @("10.0.*", "12.4.3")
         $actualOutput = Filter-Versions -Versions $inputVersions -IncludeFilters $includeFilters -ExcludeFilters $excludeFilters
         $expectedOutput = @("10.5.6", "12.5.1")
         $actualOutput | Should -Be $expectedOutput
     }
+
+    It "Exclude filter only" {
+        $includeFilters = @()
+        $excludeFilters = @("10.*", "12.*")
+        $actualOutput = Filter-Versions -Versions $inputVersions -IncludeFilters $includeFilters -ExcludeFilters $excludeFilters
+        $expectedOutput = @("8.2.1", "9.3.3", "14.2.0")
+        $actualOutput | Should -Be $expectedOutput
+    }
+
+    It "Include and exclude filters are empty" {
+        $actualOutput = Filter-Versions -Versions $inputVersions
+        $expectedOutput = @("8.2.1", "9.3.3", "10.0.2", "10.0.3", "10.5.6", "12.4.3", "12.5.1", "14.2.0")
+        $actualOutput | Should -Be $expectedOutput
+    }
 }
 
-Describe "Get-VersionsToBuild" {
+Describe "Skip-ExistingVersions" {
     It "Substract versions correctly" {
         $distInput = @("14.2.0", "14.3.0", "14.4.0", "14.4.1")
         $manifestInput = @("12.0.0", "14.2.0", "14.4.0")
-        $actualOutput = Get-VersionsToBuild -VersionsFromDist $distInput -VersionsFromManifest $manifestInput
+        $actualOutput =  Skip-ExistingVersions -VersionsFromDist $distInput -VersionsFromManifest $manifestInput
         $expectedOutput = @("14.3.0", "14.4.1")
         $actualOutput | Should -Be $expectedOutput
     }

--- a/get-new-tool-versions/get-new-tool-versions.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.ps1
@@ -6,8 +6,8 @@ Check and return list of new available tool versions
 param (
     [Parameter(Mandatory)] [string] $DistURL,
     [Parameter(Mandatory)] [string] $ManifestLink,
-    [string] $VersionFilterToInclude,
-    [string] $VersionFilterToExclude,
+    [string[]] $VersionFilterToInclude,
+    [string[]] $VersionFilterToExclude,
     [UInt32] $RetryIntervalSec = 60,
     [UInt32] $RetryCount = 3
 )
@@ -37,17 +37,9 @@ Write-Host "Get the packages list from $ManifestLink"
 
 [Version[]] $formattedVersions = Format-Versions -Versions $versionsFromDist
 
-if ($VersionFilterToInclude) {
-    $formattedVersions = Filter-Versions -Versions $formattedVersions `
-                                         -VersionFilter $VersionFilterToInclude `
-                                         -IncludeVersions $true
-}
-
-if ($VersionFilterToExclude) {
-    $formattedVersions = Filter-Versions -Versions $formattedVersions `
-                                         -VersionFilter $VersionFilterToExclude `
-                                         -IncludeVersions $false
-}
+$formattedVersions = Filter-Versions -Versions $formattedVersions `
+                                     -IncludeFilters $VersionFilterToInclude `
+                                     -ExcludeFilters $VersionFilterToExclude
 
 $versionsToBuild = Skip-ExistingVersions -VersionsFromManifest $versionsFromManifest `
                                          -VersionsFromDist $formattedVersions

--- a/get-new-tool-versions/get-new-tool-versions.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.ps1
@@ -14,6 +14,10 @@ param (
 
 Import-Module (Join-Path $PSScriptRoot "helpers.psm1")
 
+$VersionFilterToInclude.GetType()
+$VersionFilterToInclude.Length
+$VersionFilterToInclude | ForEach-Object { Write-Host $_ }
+
 function Get-VersionsByUrl {
     param (
         [Parameter(Mandatory)] [string] $ToolPackagesUrl,

--- a/get-new-tool-versions/get-new-tool-versions.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.ps1
@@ -14,10 +14,6 @@ param (
 
 Import-Module (Join-Path $PSScriptRoot "helpers.psm1")
 
-$VersionFilterToInclude.GetType()
-$VersionFilterToInclude.Length
-$VersionFilterToInclude | ForEach-Object { Write-Host $_ }
-
 function Get-VersionsByUrl {
     param (
         [Parameter(Mandatory)] [string] $ToolPackagesUrl,
@@ -27,6 +23,14 @@ function Get-VersionsByUrl {
 
     $packages = Invoke-RestMethod $ToolPackagesUrl -MaximumRetryCount $RetryCount -RetryIntervalSec $RetryIntervalSec
     return $packages.version
+}
+
+if ($VersionFilterToInclude) {
+    Validate-FiltersFormat -Filters $VersionFilterToInclude
+}
+
+if ($VersionFilterToExclude) {
+    Validate-FiltersFormat -Filters $VersionFilterToExclude
 }
 
 Write-Host "Get the packages list from $DistURL"
@@ -41,9 +45,9 @@ Write-Host "Get the packages list from $ManifestLink"
 
 [Version[]] $formattedVersions = Format-Versions -Versions $versionsFromDist
 
-$formattedVersions = Filter-Versions -Versions $formattedVersions `
-                                     -IncludeFilters $VersionFilterToInclude `
-                                     -ExcludeFilters $VersionFilterToExclude
+$formattedVersions = Select-VersionsByFilter -Versions $formattedVersions `
+                                             -IncludeFilters $VersionFilterToInclude `
+                                             -ExcludeFilters $VersionFilterToExclude
 
 $versionsToBuild = Skip-ExistingVersions -VersionsFromManifest $versionsFromManifest `
                                          -VersionsFromDist $formattedVersions

--- a/get-new-tool-versions/get-new-tool-versions.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.ps1
@@ -49,6 +49,11 @@ $formattedVersions = Select-VersionsByFilter -Versions $formattedVersions `
                                              -IncludeFilters $VersionFilterToInclude `
                                              -ExcludeFilters $VersionFilterToExclude
 
+if (-not $formattedVersions) {
+    Write-Host "Couldn't find available versions with current filters"
+    exit 1
+}
+
 $versionsToBuild = Skip-ExistingVersions -VersionsFromManifest $versionsFromManifest `
                                          -VersionsFromDist $formattedVersions
 

--- a/get-new-tool-versions/get-new-tool-versions.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.ps1
@@ -46,6 +46,7 @@ $versionsToBuild = Skip-ExistingVersions -VersionsFromManifest $versionsFromMani
 
 if ($versionsToBuild) {
     Write-Host "The following versions are available to build:`n$versionsToBuild"
+    Write-Output "##vso[task.setvariable variable=TOOL_VERSIONS]$versionsToBuild"
 } else {
     Write-Host "There isn't versions to build"
 }

--- a/get-new-tool-versions/get-new-tool-versions.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.ps1
@@ -1,6 +1,19 @@
 <#
 .SYNOPSIS
 Check and return list of new available tool versions
+
+.PARAMETER DistURL
+Required parameter. Link to the json file included all available tool versions
+.PARAMETER ManifestLink
+Required parameter. Link to the the version-manifest.json file
+.PARAMETER VersionFilterToInclude
+Optional parameter. List of filters to include particular versions
+.PARAMETER VersionFilterToExclude
+Optional parameter. List of filters to exclude particular versions
+.PARAMETER RetryIntervalSec
+Optional parameter. Retry interval in seconds
+.PARAMETER RetryCount
+Optional parameter. Retry count
 #>
 
 param (
@@ -62,5 +75,5 @@ if ($versionsToBuild) {
     Write-Host "The following versions are available to build:`n$availableVersions"
     Write-Output "##vso[task.setvariable variable=TOOL_VERSIONS]$availableVersions"
 } else {
-    Write-Host "There isn't versions to build"
+    Write-Host "There aren't versions to build"
 }

--- a/get-new-tool-versions/get-new-tool-versions.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.ps1
@@ -53,8 +53,9 @@ $versionsToBuild = Skip-ExistingVersions -VersionsFromManifest $versionsFromMani
                                          -VersionsFromDist $formattedVersions
 
 if ($versionsToBuild) {
-    Write-Host "The following versions are available to build:`n$versionsToBuild"
-    Write-Output "##vso[task.setvariable variable=TOOL_VERSIONS]$versionsToBuild"
+    $availableVersions = $versionsToBuild -join ","
+    Write-Host "The following versions are available to build:`n$availableVersions"
+    Write-Output "##vso[task.setvariable variable=TOOL_VERSIONS]$availableVersions"
 } else {
     Write-Host "There isn't versions to build"
 }

--- a/get-new-tool-versions/get-new-tool-versions.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.ps1
@@ -37,25 +37,23 @@ Write-Host "Get the packages list from $ManifestLink"
 
 [Version[]] $formattedVersions = Format-Versions -Versions $versionsFromDist
 
-if (-not ([string]::IsNullOrEmpty($VersionFilterToInclude))) {
+if ($VersionFilterToInclude) {
     $formattedVersions = Filter-Versions -Versions $formattedVersions `
                                          -VersionFilter $VersionFilterToInclude `
                                          -IncludeVersions $true
 }
 
-if (-not ([string]::IsNullOrEmpty($VersionFilterToExclude))) {
+if ($VersionFilterToExclude) {
     $formattedVersions = Filter-Versions -Versions $formattedVersions `
                                          -VersionFilter $VersionFilterToExclude `
                                          -IncludeVersions $false
 }
 
-$versionsToBuild = Get-VersionsToBuild -VersionsFromManifest $versionsFromManifest `
-                                       -VersionsFromDist $formattedVersions
+$versionsToBuild = Skip-ExistingVersions -VersionsFromManifest $versionsFromManifest `
+                                         -VersionsFromDist $formattedVersions
 
-if ([string]::IsNullOrEmpty($versionsToBuild)) {
-    Write-Host "There isn't versions to build"
-    return $null
-} else {
+if ($versionsToBuild) {
     Write-Host "The following versions are available to build:`n$versionsToBuild"
-    return "$versionsToBuild"
+} else {
+    Write-Host "There isn't versions to build"
 }

--- a/get-new-tool-versions/get-new-tool-versions.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.ps1
@@ -12,6 +12,8 @@ param (
     [UInt32] $RetryCount = 3
 )
 
+Import-Module (Join-Path $PSScriptRoot "helpers.psm1")
+
 function Get-VersionsByUrl {
     param (
         [Parameter(Mandatory)] [string] $ToolPackagesUrl,
@@ -21,74 +23,6 @@ function Get-VersionsByUrl {
 
     $packages = Invoke-RestMethod $ToolPackagesUrl -MaximumRetryCount $RetryCount -RetryIntervalSec $RetryIntervalSec
     return $packages.version
-}
-
-function Format-Versions {
-    param (
-        [Parameter(Mandatory)] [string[]] $Versions
-    )
-
-    [Version[]] $formattedVersions = @()
-    
-    foreach($version in $Versions) { 
-        $substredVersion = $null
-        
-        # We cut a string from index of first digit because initially it has invalid format (v14.4.0 or go1.14.4)
-        if ($version -match '(?<number>\d)') {
-            $firstDigitIndex = $version.indexof($Matches.number)
-            $substredVersion = $version.substring($firstDigitIndex)
-        } else {
-            Write-Host "Invalid version format - $version"
-            exit 1
-        }
-        
-        # We filter versions to exclude unstable (for example: "go1.15beta1")
-        # Valid version format: x.x or x.x.x
-        if ($substredVersion -notmatch '^\d+\.+\d+\.*\d*$') {
-            continue
-        }
-
-        if ($substredVersion.Split(".").Length -lt 3) {
-            $formattedVersions += "$substredVersion.0"
-        } else {
-            $formattedVersions += $substredVersion
-        }  
-    }
-
-    return $formattedVersions
-}
-
-function Filter-Versions {
-    param (
-        [Parameter(Mandatory)] [string[]] $Versions,
-        [Parameter(Mandatory)] [string] $VersionFilter,
-        [Parameter(Mandatory)] [bool] $IncludeVersions
-    )
-
-    $versionFilters = $VersionFilter.Split(',')
-    [Version[]] $filteredVersions = @()
-
-    foreach($filter in $versionFilters) {
-        if ($IncludeVersions) {
-            $filteredVersions += $Versions | Where-Object { $_ -like $filter }
-        } else {
-            $filteredVersions += $Versions | Where-Object { $_ -notlike $filter }
-        }
-    }
-
-    return $filteredVersions
-}
-
-function Get-VersionsToBuild {
-    param (
-        [Parameter(Mandatory)] [string[]] $VersionsFromManifest,
-        [Parameter(Mandatory)] [string[]] $VersionsFromDist
-    )
-
-    [System.Collections.ArrayList]$versionsToBuid = $VersionsFromDist
-    $VersionsFromManifest | ForEach-Object { $versionsToBuid.Remove($_) }
-
-    return $versionsToBuid
 }
 
 Write-Host "Get the packages list from $DistURL"

--- a/get-new-tool-versions/helpers.psm1
+++ b/get-new-tool-versions/helpers.psm1
@@ -1,3 +1,17 @@
+function Validate-FiltersFormat {
+    param (
+        [Parameter(Mandatory)] [string[]] $Filters
+    )
+
+    foreach($filter in $Filters) {
+        $filter.Split('.') | ForEach-Object {
+            if (($_ -notmatch '^\d+$') -and ($_ -ne '*')) {
+                throw "Invalid filter format - $filter"
+            }
+        }
+    }
+}
+
 function Format-Versions {
     param (
         [Parameter(Mandatory)] [string[]] $Versions
@@ -30,7 +44,7 @@ function Format-Versions {
     return $formattedVersions
 }
 
-function Filter-Versions {
+function Select-VersionsByFilter {
     param (
         [Parameter(Mandatory)] [version[]] $Versions,
         [string[]] $IncludeFilters,
@@ -45,8 +59,7 @@ function Filter-Versions {
         $ver = $_
         $matchedIncludeFilters = $IncludeFilters | Where-Object { $ver -like $_ }
         $matchedExcludeFilters = $ExcludeFilters | Where-Object { $ver -like $_ }
-
-        return ($matchedIncludeFilters -ne $null) -and ($matchedExcludeFilters -eq $null)
+        return ($null -ne $matchedIncludeFilters) -and ($null -eq $matchedExcludeFilters)
     }
 }
 

--- a/get-new-tool-versions/helpers.psm1
+++ b/get-new-tool-versions/helpers.psm1
@@ -8,16 +8,15 @@ function Format-Versions {
     foreach($version in $Versions) { 
         $substredVersion = $null
         
-        # We cut a string from index of first digit because initially it has invalid format (v14.4.0 or go1.14.4)
-        if ($version -match '(?<number>\d)') {
-            $firstDigitIndex = $version.indexof($Matches.number)
-            $substredVersion = $version.substring($firstDigitIndex)
-        } else {
+        # Cut a string from index of first digit because initially it has invalid format (v14.4.0 or go1.14.4)
+        if (-not ($version -match '(?<number>\d)')) {
             Write-Host "Invalid version format - $version"
-            exit 1
+            exit 1  
         }
+        $firstDigitIndex = $version.indexof($Matches.number)
+        $substredVersion = $version.substring($firstDigitIndex)
         
-        # We filter versions to exclude unstable (for example: "go1.15beta1")
+        # Filter versions to exclude unstable (for example: "go1.15beta1")
         # Valid version format: x.x or x.x.x
         if ($substredVersion -notmatch '^\d+\.+\d+\.*\d*$') {
             continue
@@ -54,14 +53,14 @@ function Filter-Versions {
     return $filteredVersions
 }
 
-function Get-VersionsToBuild {
+function Skip-ExistingVersions {
     param (
         [Parameter(Mandatory)] [string[]] $VersionsFromManifest,
         [Parameter(Mandatory)] [string[]] $VersionsFromDist
     )
 
-    [System.Collections.ArrayList]$versionsToBuid = $VersionsFromDist
-    $VersionsFromManifest | ForEach-Object { $versionsToBuid.Remove($_) }
+    $newVersions = @()
+    $newVersions += $VersionsFromDist | Where-Object { $VersionsFromManifest -notcontains $_ }
 
-    return $versionsToBuid
+    return $newVersions
 }

--- a/get-new-tool-versions/helpers.psm1
+++ b/get-new-tool-versions/helpers.psm1
@@ -1,0 +1,67 @@
+function Format-Versions {
+    param (
+        [Parameter(Mandatory)] [string[]] $Versions
+    )
+
+    [Version[]] $formattedVersions = @()
+    
+    foreach($version in $Versions) { 
+        $substredVersion = $null
+        
+        # We cut a string from index of first digit because initially it has invalid format (v14.4.0 or go1.14.4)
+        if ($version -match '(?<number>\d)') {
+            $firstDigitIndex = $version.indexof($Matches.number)
+            $substredVersion = $version.substring($firstDigitIndex)
+        } else {
+            Write-Host "Invalid version format - $version"
+            exit 1
+        }
+        
+        # We filter versions to exclude unstable (for example: "go1.15beta1")
+        # Valid version format: x.x or x.x.x
+        if ($substredVersion -notmatch '^\d+\.+\d+\.*\d*$') {
+            continue
+        }
+
+        if ($substredVersion.Split(".").Length -lt 3) {
+            $formattedVersions += "$substredVersion.0"
+        } else {
+            $formattedVersions += $substredVersion
+        }  
+    }
+
+    return $formattedVersions
+}
+
+function Filter-Versions {
+    param (
+        [Parameter(Mandatory)] [string[]] $Versions,
+        [Parameter(Mandatory)] [string] $VersionFilter,
+        [Parameter(Mandatory)] [bool] $IncludeVersions
+    )
+
+    $versionFilters = $VersionFilter.Split(',')
+    [Version[]] $filteredVersions = @()
+
+    foreach($filter in $versionFilters) {
+        if ($IncludeVersions) {
+            $filteredVersions += $Versions | Where-Object { $_ -like $filter }
+        } else {
+            $filteredVersions += $Versions | Where-Object { $_ -notlike $filter }
+        }
+    }
+
+    return $filteredVersions
+}
+
+function Get-VersionsToBuild {
+    param (
+        [Parameter(Mandatory)] [string[]] $VersionsFromManifest,
+        [Parameter(Mandatory)] [string[]] $VersionsFromDist
+    )
+
+    [System.Collections.ArrayList]$versionsToBuid = $VersionsFromDist
+    $VersionsFromManifest | ForEach-Object { $versionsToBuid.Remove($_) }
+
+    return $versionsToBuid
+}

--- a/get-new-tool-versions/helpers.psm1
+++ b/get-new-tool-versions/helpers.psm1
@@ -59,7 +59,7 @@ function Select-VersionsByFilter {
         $ver = $_
         $matchedIncludeFilters = $IncludeFilters | Where-Object { $ver -like $_ }
         $matchedExcludeFilters = $ExcludeFilters | Where-Object { $ver -like $_ }
-        return ($null -ne $matchedIncludeFilters) -and ($null -eq $matchedExcludeFilters)
+        $matchedIncludeFilters -and (-not $matchedExcludeFilters)
     }
 }
 


### PR DESCRIPTION
In scope of this PR we've implemented the `get-new-tool-versions.ps1` script to get new available tool versions

**Details:**
 The `get-new-tool-versions.ps1` script checks difference between the `version-manifest.json` file placed in a `actions/toolname-versions` repository and a json file included all available versions of tool in order to get a list of new available tool versions. We added ability to specify two filters to include and/or exclude particular versions. Examples of valid filters: `12.2`, `12.2.0`, `12.*`, etc.

We also added pester tests to cover functions located in the `helpers.psm1` script.

**Related issue:** [#752](https://github.com/actions/virtual-environments-internal/issues/752)