### PR TITLE
Configure CI to get tools versions

### DIFF
--- a/azure-devops/azure-devops-api.ps1
+++ b/azure-devops/azure-devops-api.ps1
@@ -56,6 +56,15 @@ class AzureDevOpsApi
         return $this.InvokeRestMethod($url, 'GET', $null)
     }
 
+    [object] UpdateBuildStatus([UInt32]$BuildId, [string]$BuildStatus){
+        $url = "build/builds/$BuildId"
+        $body = @{ 
+            status = $BuildStatus 
+        } | ConvertTo-Json
+
+        return $this.InvokeRestMethod($url, 'PATCH', $body)
+    }
+
     [string] hidden BuildUrl([string]$Url) {
         return "$($this.BaseUrl)/${Url}/?api-version=5.1"
     }

--- a/azure-pipelines/get-tool-versions.yml
+++ b/azure-pipelines/get-tool-versions.yml
@@ -1,0 +1,32 @@
+name: $(date:yyyyMMdd)$(rev:.r)
+trigger: none
+pr: none
+
+stages:
+- stage: Get_New_Versions
+  dependsOn: []
+  jobs:
+  - job: Get_Tool_Versions
+    timeoutInMinutes: 30
+    pool:
+      name: Azure Pipelines
+      vmImage: 'ubuntu-18.04'
+    steps:
+    - template: /azure-pipelines/templates/get-tool-versions-steps.yml
+
+- stage: Trigger_Builds
+  dependsOn: Get_New_Versions
+  jobs:
+  - deployment: Run_Builds
+    pool:
+      name: Azure Pipelines
+      vmImage: 'ubuntu-18.04'
+    variables:
+      ToolVersions: $[ stageDependencies.Get_New_Versions.Get_Tool_Versions.outputs['Get_versions.TOOL_VERSIONS'] ]
+    timeoutInMinutes: 180
+    environment: 'Get Available Tools Versions - Publishing Approval'
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - template: /azure-pipelines/templates/run-ci-builds-steps.yml

--- a/azure-pipelines/get-tool-versions.yml
+++ b/azure-pipelines/get-tool-versions.yml
@@ -1,13 +1,25 @@
 name: $(date:yyyyMMdd)$(rev:.r)
 trigger: none
 pr: none
+schedules:
+- cron: "0 3 * * *"
+  displayName: First daily build
+  branches:
+    include:
+    - master
+  always: true
+- cron: "0 15 * * *"
+  displayName: Second daily build
+  branches:
+    include:
+    - master
+  always: true
 
 stages:
 - stage: Get_New_Versions
   dependsOn: []
   jobs:
   - job: Get_Tool_Versions
-    timeoutInMinutes: 30
     pool:
       name: Azure Pipelines
       vmImage: 'ubuntu-18.04'

--- a/azure-pipelines/get-tool-versions.yml
+++ b/azure-pipelines/get-tool-versions.yml
@@ -15,14 +15,18 @@ schedules:
     - master
   always: true
 
+variables:
+  PoolName: 'Azure Pipelines'
+  VmImage: 'ubuntu-18.04'
+
 stages:
 - stage: Get_New_Versions
   dependsOn: []
   jobs:
   - job: Get_Tool_Versions
     pool:
-      name: Azure Pipelines
-      vmImage: 'ubuntu-18.04'
+      name: $(PoolName)
+      vmImage: $(VmImage)
     steps:
     - template: /azure-pipelines/templates/get-tool-versions-steps.yml
 
@@ -31,8 +35,8 @@ stages:
   jobs:
   - deployment: Run_Builds
     pool:
-      name: Azure Pipelines
-      vmImage: 'ubuntu-18.04'
+      name: $(PoolName)
+      vmImage: $(VmImage)
     variables:
       ToolVersions: $[ stageDependencies.Get_New_Versions.Get_Tool_Versions.outputs['Get_versions.TOOL_VERSIONS'] ]
     timeoutInMinutes: 180

--- a/azure-pipelines/templates/get-tool-versions-steps.yml
+++ b/azure-pipelines/templates/get-tool-versions-steps.yml
@@ -1,0 +1,53 @@
+steps:
+- task: PowerShell@2
+  displayName: 'Get new versions'
+  name: 'Get_versions'
+  inputs:
+    targetType: filePath
+    filePath: './get-new-tool-versions/get-new-tool-versions.ps1'
+    arguments: |
+        -DistURL "$(DIST_URL)" `
+        -ManifestLink "$(MANIFEST_URL)" `
+        -VersionFilterToInclude $(INCLUDE_FILTER) `
+        -VersionFilterToExclude $(EXCLUDE_FILTER) `
+        -RetryIntervalSec $(INTERVAL_SEC) `
+        -RetryCount $(RETRY_COUNT)
+
+- task: PowerShell@2
+  displayName: 'Cancel build'
+  condition: and(succeeded(), eq(variables['Get_versions.TOOL_VERSIONS'], ''))
+  inputs:
+    TargetType: inline
+    script: |
+      Import-Module "./azure-devops/azure-devops-api.ps1"
+      $azureDevOpsApi = Get-AzureDevOpsApi -TeamFoundationCollectionUri $(System.TeamFoundationCollectionUri) `
+                                           -ProjectName $(System.TeamProject) `
+                                           -AccessToken $(System.AccessToken) `
+                                           -RetryCount $(INTERVAL_SEC) `
+                                           -RetryIntervalSec $(RETRY_COUNT)
+
+      $AzureDevOpsApi.UpdateBuildStatus($(Build.BuildId), 'Cancelling') | Out-Null
+
+- task: PowerShell@2
+  displayName: 'Set env variables'
+  condition: and(succeeded(), ne(variables['Get_versions.TOOL_VERSIONS'], ''))
+  inputs:
+    TargetType: inline
+    script: |
+      $PipelineUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"
+      Write-Output "##vso[task.setvariable variable=PIPELINE_URL]$PipelineUrl"
+      $toolVersion = "$(Get_versions.TOOL_VERSIONS)".Replace(",",", ")
+      Write-Output "##vso[task.setvariable variable=TOOL_VERSIONS]$toolVersion"
+
+- task: PowerShell@2
+  displayName: 'Send Slack notification'
+  condition: and(succeeded(), ne(variables['Get_versions.TOOL_VERSIONS'], ''))
+  inputs:
+    targetType: filePath
+    filePath: './get-new-tool-versions/send-slack-notification.ps1'
+    arguments: |
+      -Url "$(SLACK_CHANNEL_URL)" `
+      -ToolName "$(TOOL_NAME)" `
+      -ToolVersion "$(TOOL_VERSIONS)" `
+      -PipelineUrl "$(PIPELINE_URL)" `
+      -ImageUrl "$(IMAGE_URL)"

--- a/azure-pipelines/templates/get-tool-versions-steps.yml
+++ b/azure-pipelines/templates/get-tool-versions-steps.yml
@@ -9,9 +9,7 @@ steps:
         -DistURL "$(DIST_URL)" `
         -ManifestLink "$(MANIFEST_URL)" `
         -VersionFilterToInclude $(INCLUDE_FILTER) `
-        -VersionFilterToExclude $(EXCLUDE_FILTER) `
-        -RetryIntervalSec $(INTERVAL_SEC) `
-        -RetryCount $(RETRY_COUNT)
+        -VersionFilterToExclude $(EXCLUDE_FILTER)
 
 - task: PowerShell@2
   displayName: 'Cancel build'
@@ -22,22 +20,18 @@ steps:
       Import-Module "./azure-devops/azure-devops-api.ps1"
       $azureDevOpsApi = Get-AzureDevOpsApi -TeamFoundationCollectionUri $(System.TeamFoundationCollectionUri) `
                                            -ProjectName $(System.TeamProject) `
-                                           -AccessToken $(System.AccessToken) `
-                                           -RetryCount $(INTERVAL_SEC) `
-                                           -RetryIntervalSec $(RETRY_COUNT)
+                                           -AccessToken $(System.AccessToken)
 
       $AzureDevOpsApi.UpdateBuildStatus($(Build.BuildId), 'Cancelling') | Out-Null
 
 - task: PowerShell@2
-  displayName: 'Set env variables'
+  displayName: 'Set env variable'
   condition: and(succeeded(), ne(variables['Get_versions.TOOL_VERSIONS'], ''))
   inputs:
     TargetType: inline
     script: |
       $PipelineUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"
       Write-Output "##vso[task.setvariable variable=PIPELINE_URL]$PipelineUrl"
-      $toolVersion = "$(Get_versions.TOOL_VERSIONS)".Replace(",",", ")
-      Write-Output "##vso[task.setvariable variable=TOOL_VERSIONS]$toolVersion"
 
 - task: PowerShell@2
   displayName: 'Send Slack notification'
@@ -48,6 +42,6 @@ steps:
     arguments: |
       -Url "$(SLACK_CHANNEL_URL)" `
       -ToolName "$(TOOL_NAME)" `
-      -ToolVersion "$(TOOL_VERSIONS)" `
+      -ToolVersion "$(Get_versions.TOOL_VERSIONS)" `
       -PipelineUrl "$(PIPELINE_URL)" `
       -ImageUrl "$(IMAGE_URL)"

--- a/azure-pipelines/templates/run-ci-builds-steps.yml
+++ b/azure-pipelines/templates/run-ci-builds-steps.yml
@@ -22,7 +22,7 @@ steps:
         -SourceBranch $(BRANCH) `
         -DefinitionId $(DEFINITION_ID) `
         -SourceVersion $(COMMIT_SHA) `
-        -ManifestLink $(MANIFEST_LINK) `
+        -ManifestLink $(MANIFEST_URL) `
         -WaitForBuilds $(WAIT_FOR_BUILDS) `
         -ToolVersions "$(ToolVersions)" `
         -RetryIntervalSec $(INTERVAL_SEC) `

--- a/azure-pipelines/templates/run-ci-builds-steps.yml
+++ b/azure-pipelines/templates/run-ci-builds-steps.yml
@@ -1,0 +1,29 @@
+steps:
+- checkout: self
+
+- task: PowerShell@2
+  displayName: 'Get source version'
+  inputs:
+    TargetType: inline
+    script: |
+      $url = "https://api.github.com/repos/$(REPOSITORY)/commits/$(BRANCH)"
+      $commit = Invoke-RestMethod -Uri $url -Method "GET"
+      Write-Output "##vso[task.setvariable variable=COMMIT_SHA]$($commit.sha)"
+
+- task: PowerShell@2
+  displayName: 'Run builds'
+  inputs:
+    targetType: filePath
+    filePath: './azure-devops/run-ci-builds.ps1'
+    arguments: |
+        -TeamFoundationCollectionUri $(System.TeamFoundationCollectionUri) `
+        -AzureDevOpsProjectName $(System.TeamProject) `
+        -AzureDevOpsAccessToken $(System.AccessToken) `
+        -SourceBranch $(BRANCH) `
+        -DefinitionId $(DEFINITION_ID) `
+        -SourceVersion $(COMMIT_SHA) `
+        -ManifestLink $(MANIFEST_LINK) `
+        -WaitForBuilds $(WAIT_FOR_BUILDS) `
+        -ToolVersions "$(ToolVersions)" `
+        -RetryIntervalSec $(INTERVAL_SEC) `
+        -RetryCount $(RETRY_COUNT)

--- a/get-new-tool-versions/get-new-tool-versions.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.ps1
@@ -72,8 +72,9 @@ $versionsToBuild = Skip-ExistingVersions -VersionsFromManifest $versionsFromMani
 
 if ($versionsToBuild) {
     $availableVersions = $versionsToBuild -join ","
-    Write-Host "The following versions are available to build:`n$availableVersions"
-    Write-Output "##vso[task.setvariable variable=TOOL_VERSIONS;isOutput=true]$availableVersions"
+    $toolVersions = $availableVersions.Replace(",",", ")
+    Write-Host "The following versions are available to build:`n$toolVersions"
+    Write-Output "##vso[task.setvariable variable=TOOL_VERSIONS;isOutput=true]$toolVersions"
 } else {
     Write-Host "There aren't versions to build"
 }

--- a/get-new-tool-versions/get-new-tool-versions.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.ps1
@@ -73,7 +73,7 @@ $versionsToBuild = Skip-ExistingVersions -VersionsFromManifest $versionsFromMani
 if ($versionsToBuild) {
     $availableVersions = $versionsToBuild -join ","
     Write-Host "The following versions are available to build:`n$availableVersions"
-    Write-Output "##vso[task.setvariable variable=TOOL_VERSIONS]$availableVersions"
+    Write-Output "##vso[task.setvariable variable=TOOL_VERSIONS;isOutput=true]$availableVersions"
 } else {
     Write-Host "There aren't versions to build"
 }

--- a/get-new-tool-versions/send-slack-notification.ps1
+++ b/get-new-tool-versions/send-slack-notification.ps1
@@ -60,4 +60,3 @@ $jsonBodyMessage = @"
 
 # Send Slack message
 $null = Send-SlackPostMessageIncomingWebHook -Uri $url -Body $jsonBodyMessage
-Write-Host "Message template: `n $jsonBodyMessage"


### PR DESCRIPTION
In scope of this PR we configured CI to get tools (Go, Node, etc.) versions.

**Details:**
We configured yml files with two stages. `Get_New_Versions` stage contains logic to get new available versions of tool, send notification to a slack channel and cancel build in case when versions are not found. For these purposes we added `UpdateBuildStatus` method to the `azure-devops-api.ps1` script. When versions are found the `Trigger_Builds` stage waits for manual approval to trigger `toolName-packages-generation` builds.

**Links:**
- [get-go-versions](https://github.visualstudio.com/virtual-environments/_build?definitionId=77) pipeline
- [get-node-versions](https://github.visualstudio.com/virtual-environments/_build?definitionId=78&_a=summary) pipeline

**Slack notification example:**
![image](https://user-images.githubusercontent.com/46996400/86621416-d834f300-bfc6-11ea-8b11-0047241b81eb.png)
