### PR TITLE
Add support unstable tool versions

### DIFF
--- a/packages-generation/manifest-generator.ps1
+++ b/packages-generation/manifest-generator.ps1
@@ -31,6 +31,5 @@ $configuration = Read-ConfigurationFile -Filepath $ConfigurationFile
 
 $gitHubApi = Get-GitHubApi -AccountName $GitHubRepositoryOwner -ProjectName $GitHubRepositoryName -AccessToken $GitHubAccessToken
 $releases = $gitHubApi.GetReleases()
-
 $versionIndex = Build-VersionsManifest -Releases $releases -Configuration $configuration
 $versionIndex | ConvertTo-Json -Depth 5 | Out-File $OutputFile -Encoding UTF8NoBOM -Force

--- a/packages-generation/manifest-generator.ps1
+++ b/packages-generation/manifest-generator.ps1
@@ -31,5 +31,6 @@ $configuration = Read-ConfigurationFile -Filepath $ConfigurationFile
 
 $gitHubApi = Get-GitHubApi -AccountName $GitHubRepositoryOwner -ProjectName $GitHubRepositoryName -AccessToken $GitHubAccessToken
 $releases = $gitHubApi.GetReleases()
+
 $versionIndex = Build-VersionsManifest -Releases $releases -Configuration $configuration
 $versionIndex | ConvertTo-Json -Depth 5 | Out-File $OutputFile -Encoding UTF8NoBOM -Force

--- a/packages-generation/manifest-utils.Tests.ps1
+++ b/packages-generation/manifest-utils.Tests.ps1
@@ -60,6 +60,17 @@ Describe "Get-VersionFromRelease" {
         $release = @{ name = "3.8.3: Release title" }
         Get-VersionFromRelease -Release $release | Should -Be "3.8.3"
     }
+
+    It "take alpha, beta or rc version" {
+        $release = @{ name = "3.8.3-alpha.1"}
+        Get-VersionFromRelease -Release $release | Should -Be "3.8.3-alpha.1"
+
+        $release = @{ name = "3.8.3-beta.2"}
+        Get-VersionFromRelease -Release $release | Should -Be "3.8.3-alpha.2"
+
+        $release = @{ name = "3.8.3-rc.1"}
+        Get-VersionFromRelease -Release $release | Should -Be "3.8.3-rc.1"
+    }
 }
 
 Describe "Build-VersionsManifest" {
@@ -78,14 +89,28 @@ Describe "Build-VersionsManifest" {
 
     It "build manifest with correct version order" {
         $releases = @(
-            @{ name = "3.8.1"; draft = $false; prerelease = $false; html_url = "fake_html_url"; published_at = "2020-05-14T09:54:06Z"; assets = $assets },
+            @{ name = "3.8.1-beta.2"; draft = $false; prerelease = $false; html_url = "fake_html_url"; published_at = "2020-05-14T09:54:06Z"; assets = $assets },
             @{ name = "3.5.2: Hello"; draft = $false; prerelease = $false; html_url = "fake_html_url"; published_at = "2020-05-06T11:45:36Z"; assets = $assets },
-            @{ name = "3.8.3: Release title"; draft = $false; prerelease = $false; html_url = "fake_html_url"; published_at = "2020-05-06T11:43:38Z"; assets = $assets }
+            @{ name = "3.8.3-alpha.1"; draft = $false; prerelease = $false; html_url = "fake_html_url"; published_at = "2020-05-06T11:43:38Z"; assets = $assets }
+            @{ name = "3.8.1-rc.1"; draft = $false; prerelease = $false; html_url = "fake_html_url"; published_at = "2020-05-06T11:43:38Z"; assets = $assets }
+            @{ name = "3.8.1-beta.1"; draft = $false; prerelease = $false; html_url = "fake_html_url"; published_at = "2020-05-06T11:43:38Z"; assets = $assets }
+            @{ name = "3.4.7"; draft = $false; prerelease = $false; html_url = "fake_html_url"; published_at = "2020-05-06T11:43:38Z"; assets = $assets }
+            @{ name = "3.8.1-alpha.3"; draft = $false; prerelease = $false; html_url = "fake_html_url"; published_at = "2020-05-06T11:43:38Z"; assets = $assets }
+            @{ name = "3.8.1-beta.12"; draft = $false; prerelease = $false; html_url = "fake_html_url"; published_at = "2020-05-06T11:43:38Z"; assets = $assets }
+            @{ name = "3.5.2-beta.2"; draft = $false; prerelease = $false; html_url = "fake_html_url"; published_at = "2020-05-06T11:43:38Z"; assets = $assets }
+            @{ name = "3.8.1"; draft = $false; prerelease = $false; html_url = "fake_html_url"; published_at = "2020-05-06T11:43:38Z"; assets = $assets }
         )
         $expectedManifest = @(
-            [PSCustomObject]@{ version = "3.8.3"; stable = $true; release_url = "fake_html_url"; files = $expectedManifestFiles },
+            [PSCustomObject]@{ version = "3.8.3-alpha.1"; stable = $false; release_url = "fake_html_url"; files = $expectedManifestFiles },
             [PSCustomObject]@{ version = "3.8.1"; stable = $true; release_url = "fake_html_url"; files = $expectedManifestFiles },
+            [PSCustomObject]@{ version = "3.8.1-rc.1"; stable = $false; release_url = "fake_html_url"; files = $expectedManifestFiles }
+            [PSCustomObject]@{ version = "3.8.1-beta.12"; stable = $false; release_url = "fake_html_url"; files = $expectedManifestFiles }
+            [PSCustomObject]@{ version = "3.8.1-beta.2"; stable = $false; release_url = "fake_html_url"; files = $expectedManifestFiles }
+            [PSCustomObject]@{ version = "3.8.1-beta.1"; stable = $false; release_url = "fake_html_url"; files = $expectedManifestFiles }
+            [PSCustomObject]@{ version = "3.8.1-alpha.3"; stable = $false; release_url = "fake_html_url"; files = $expectedManifestFiles }
             [PSCustomObject]@{ version = "3.5.2"; stable = $true; release_url = "fake_html_url"; files = $expectedManifestFiles }
+            [PSCustomObject]@{ version = "3.5.2-beta.2"; stable = $false; release_url = "fake_html_url"; files = $expectedManifestFiles }
+            [PSCustomObject]@{ version = "3.4.7"; stable = $true; release_url = "fake_html_url"; files = $expectedManifestFiles }
         )
         $actualManifest = Build-VersionsManifest -Releases $releases -Configuration $configuration
         Assert-Equivalent -Actual $actualManifest -Expected $expectedManifest

--- a/packages-generation/manifest-utils.Tests.ps1
+++ b/packages-generation/manifest-utils.Tests.ps1
@@ -66,7 +66,7 @@ Describe "Get-VersionFromRelease" {
         Get-VersionFromRelease -Release $release | Should -Be "3.8.3-alpha.1"
 
         $release = @{ name = "3.8.3-beta.2"}
-        Get-VersionFromRelease -Release $release | Should -Be "3.8.3-alpha.2"
+        Get-VersionFromRelease -Release $release | Should -Be "3.8.3-beta.2"
 
         $release = @{ name = "3.8.3-rc.1"}
         Get-VersionFromRelease -Release $release | Should -Be "3.8.3-rc.1"


### PR DESCRIPTION
Type `Version` replaced to `Semver` that allows to handle alpha, beta and other versions with pre-release label (e.g. 3.9.0-beta.1, 3.9.0-rc.2). Field `stable` in the manifest file for unstable versions has value `false`.

Example of generated manifest file: https://github.com/vsafonkin/python-versions/blob/update-versions-manifest-file/versions-manifest.json

workitem: [#797](https://github.com/actions/virtual-environments-internal/issues/797)