### PR TITLE
Migrate tools CI to GitHub Actions

### DIFF
--- a/azure-pipelines/templates/run-ci-builds-steps.yml
+++ b/azure-pipelines/templates/run-ci-builds-steps.yml
@@ -2,28 +2,14 @@ steps:
 - checkout: self
 
 - task: PowerShell@2
-  displayName: 'Get source version'
-  inputs:
-    TargetType: inline
-    script: |
-      $url = "https://api.github.com/repos/$(REPOSITORY)/commits/$(BRANCH)"
-      $commit = Invoke-RestMethod -Uri $url -Method "GET"
-      Write-Output "##vso[task.setvariable variable=COMMIT_SHA]$($commit.sha)"
-
-- task: PowerShell@2
   displayName: 'Run builds'
   inputs:
     targetType: filePath
-    filePath: './azure-devops/run-ci-builds.ps1'
+    filePath: './github/run-ci-builds.ps1'
     arguments: |
-        -TeamFoundationCollectionUri $(System.TeamFoundationCollectionUri) `
-        -AzureDevOpsProjectName $(System.TeamProject) `
-        -AzureDevOpsAccessToken $(System.AccessToken) `
-        -SourceBranch $(BRANCH) `
-        -DefinitionId $(DEFINITION_ID) `
-        -SourceVersion $(COMMIT_SHA) `
-        -ManifestLink $(MANIFEST_URL) `
-        -WaitForBuilds $(WAIT_FOR_BUILDS) `
+        -RepositoryFullName $(REPOSITORY_FULL_NAME) `
+        -AccessToken $(GITHUB_TOKEN) `
+        -WorkflowFileName $(WORKFLOW_FILE_NAME) `
+        -WorkflowDispatchRef $(DISPATCH_REF) `
         -ToolVersions "$(ToolVersions)" `
-        -RetryIntervalSec $(INTERVAL_SEC) `
-        -RetryCount $(RETRY_COUNT)
+        -PublishReleases $(PUPLISH_RELEASES)

--- a/clean-toolcache.ps1
+++ b/clean-toolcache.ps1
@@ -3,6 +3,11 @@ param (
 )
 
 $targetPath = $env:AGENT_TOOLSDIRECTORY
+if ([string]::IsNullOrEmpty($targetPath)) {
+    # GitHub Windows images don't have `AGENT_TOOLSDIRECTORY` variable
+    $targetPath = $env:RUNNER_TOOL_CACHE
+}
+
 if ($ToolName) {
     $targetPath = Join-Path $targetPath $ToolName
 }

--- a/github/create-pull-request.ps1
+++ b/github/create-pull-request.ps1
@@ -85,8 +85,7 @@ Write-Host "Push branch: $BranchName"
 Git-PushBranch -Name $BranchName -Force $true
 
 $gitHubApi = Get-GitHubApi -RepositoryFullName $RepositoryFullName -AccessToken $AccessToken
-$repositoryOwner = $RepositoryFullName.Split('/')[0]
-$pullRequest = $gitHubApi.GetPullRequest($BranchName, $repositoryOwner)
+$pullRequest = $gitHubApi.GetPullRequest($BranchName)
 
 if ($pullRequest.Count -gt 0) {
     Write-Host "Update pull request"

--- a/github/create-pull-request.ps1
+++ b/github/create-pull-request.ps1
@@ -84,7 +84,7 @@ Git-CommitAllChanges -Message $CommitMessage
 Write-Host "Push branch: $BranchName"
 Git-PushBranch -Name $BranchName -Force $true
 
-$gitHubApi = Get-GitHubApi -RepositoryFullName $RepositoryFullName -AccessToken $AccessToken
+$gitHubApi = Get-GitHubApi -RepositoryName $RepositoryFullName -AccessToken $AccessToken
 $repositoryOwner = $RepositoryFullName.Split('/')[0]
 $pullRequest = $gitHubApi.GetPullRequest($BranchName, $repositoryOwner)
 

--- a/github/create-pull-request.ps1
+++ b/github/create-pull-request.ps1
@@ -84,7 +84,7 @@ Git-CommitAllChanges -Message $CommitMessage
 Write-Host "Push branch: $BranchName"
 Git-PushBranch -Name $BranchName -Force $true
 
-$gitHubApi = Get-GitHubApi -RepositoryName $RepositoryFullName -AccessToken $AccessToken
+$gitHubApi = Get-GitHubApi -RepositoryFullName $RepositoryFullName -AccessToken $AccessToken
 $repositoryOwner = $RepositoryFullName.Split('/')[0]
 $pullRequest = $gitHubApi.GetPullRequest($BranchName, $repositoryOwner)
 

--- a/github/github-api.psm1
+++ b/github/github-api.psm1
@@ -8,10 +8,11 @@ class GitHubApi
     [object] $AuthHeader
 
     GitHubApi(
-        [string] $RepositoryFullName,
+        [string] $AccountName,
+        [string] $ProjectName,
         [string] $AccessToken
     ) {
-        $this.BaseUrl = $this.BuildBaseUrl($RepositoryFullName)
+        $this.BaseUrl = $this.BuildBaseUrl($AccountName, $ProjectName)
         $this.AuthHeader = $this.BuildAuth($AccessToken)
     }
 
@@ -25,8 +26,8 @@ class GitHubApi
         }
     }
 
-    [string] hidden BuildBaseUrl([string]$RepositoryFullName) {
-        return "https://api.github.com/repos/$RepositoryFullName"
+    [string] hidden BuildBaseUrl([string]$RepositoryOwner, [string]$RepositoryName) {
+        return "https://api.github.com/repos/$RepositoryOwner/$RepositoryName"
     }
 
     [object] CreateNewPullRequest([string]$Title, [string]$Body, [string]$BranchName){
@@ -144,9 +145,20 @@ class GitHubApi
 
 function Get-GitHubApi {
     param (
-        [string] $RepositoryFullName,
+        [Parameter(ParameterSetName = 'RepositoryOwner')]
+        [Parameter(ParameterSetName = 'RepositoryName')]
+        [string] $RepositoryOwner,
+
+        [Parameter(ParameterSetName = 'RepositoryName')]
+        [string] $RepositoryName,
+
         [string] $AccessToken
     )
 
-    return [GitHubApi]::New($RepositoryFullName, $AccessToken)
+    # Split repository name (like 'actions/versions-package-tools') in case when owner is not set
+    if (-not $RepositoryOwner) {
+        $RepositoryOwner = $RepositoryName.Split('/')[0]
+    }
+
+    return [GitHubApi]::New($RepositoryOwner, $RepositoryName, $AccessToken)
 }

--- a/github/github-api.psm1
+++ b/github/github-api.psm1
@@ -155,7 +155,7 @@ function Get-GitHubApi {
     )
 
     if ($PSCmdlet.ParameterSetName -eq "RepositorySingle") {
-        $RepositoryOwner, $RepositoryName = $Repository.Split('/', 2)
+        $RepositoryOwner, $RepositoryName = $RepositoryFullName.Split('/', 2)
     }
 
     return [GitHubApi]::New($RepositoryOwner, $RepositoryName, $AccessToken)

--- a/github/github-api.psm1
+++ b/github/github-api.psm1
@@ -145,19 +145,17 @@ class GitHubApi
 
 function Get-GitHubApi {
     param (
-        [Parameter(ParameterSetName = 'RepositoryOwner')]
-        [Parameter(ParameterSetName = 'RepositoryName')]
+        [Parameter(ParameterSetName = 'RepositorySingle')]
+        [string] $RepositoryFullName,
+        [Parameter(ParameterSetName = 'RepositorySplitted')]
         [string] $RepositoryOwner,
-
-        [Parameter(ParameterSetName = 'RepositoryName')]
+        [Parameter(ParameterSetName = 'RepositorySplitted')]
         [string] $RepositoryName,
-
         [string] $AccessToken
     )
 
-    # Split repository name (like 'actions/versions-package-tools') in case when owner is not set
-    if (-not $RepositoryOwner) {
-        $RepositoryOwner = $RepositoryName.Split('/')[0]
+    if ($PSCmdlet.ParameterSetName -eq "RepositorySingle") {
+        $RepositoryOwner, $RepositoryName = $Repository.Split('/', 2)
     }
 
     return [GitHubApi]::New($RepositoryOwner, $RepositoryName, $AccessToken)

--- a/github/github-api.psm1
+++ b/github/github-api.psm1
@@ -6,6 +6,7 @@ class GitHubApi
 {
     [string] $BaseUrl
     [object] $AuthHeader
+    [string] $RepositoryOwner
 
     GitHubApi(
         [string] $AccountName,
@@ -14,6 +15,7 @@ class GitHubApi
     ) {
         $this.BaseUrl = $this.BuildBaseUrl($AccountName, $ProjectName)
         $this.AuthHeader = $this.BuildAuth($AccessToken)
+        $this.RepositoryOwner = $AccountName
     }
 
     [object] hidden BuildAuth([string]$AccessToken) {
@@ -42,9 +44,9 @@ class GitHubApi
         return $this.InvokeRestMethod($url, 'Post', $null, $requestBody)
     }
 
-    [object] GetPullRequest([string]$BranchName, [string]$RepositoryOwner){
+    [object] GetPullRequest([string]$BranchName){
         $url = "pulls"
-        return $this.InvokeRestMethod($url, 'GET', "head=${RepositoryOwner}:$BranchName&base=main", $null)
+        return $this.InvokeRestMethod($url, 'GET', "head=$($this.RepositoryOwner):${BranchName}&base=main", $null)
     }
 
     [object] UpdatePullRequest([string]$Title, [string]$Body, [string]$BranchName, [string]$PullRequestNumber){

--- a/github/run-ci-builds.ps1
+++ b/github/run-ci-builds.ps1
@@ -81,7 +81,7 @@ function Queue-Builds {
     }
 }
 
-$gitHubApi = Get-GitHubApi -RepositoryName $RepositoryFullName -AccessToken $AccessToken
+$gitHubApi = Get-GitHubApi -RepositoryFullName $RepositoryFullName -AccessToken $AccessToken
 
 Write-Host "Versions to build: $ToolVersions"
 Queue-Builds -GitHubApi $gitHubApi `

--- a/github/run-ci-builds.ps1
+++ b/github/run-ci-builds.ps1
@@ -1,0 +1,91 @@
+<#
+.SYNOPSIS
+Trigger runs on the workflow_dispatch event to build and upload tool packages
+
+.PARAMETER RepositoryFullName
+Required parameter. The owner and repository name. For example, 'actions/versions-package-tools'
+.PARAMETER AccessToken
+Required parameter. PAT Token to authorize
+.PARAMETER WorkflowFileName
+Required parameter. The name of workflow file that will be triggered
+.PARAMETER WorkflowDispatchRef
+Required parameter. The reference of the workflow run. The reference can be a branch, tag, or a commit SHA.
+.PARAMETER ToolVersions
+Required parameter. List of tool versions to build and upload
+.PARAMETER PublishReleases
+Required parameter. Whether to publish releases, true or false
+#>
+
+param (
+    [Parameter(Mandatory)] [string] $RepositoryFullName,
+    [Parameter(Mandatory)] [string] $AccessToken,
+    [Parameter(Mandatory)] [string] $WorkflowFileName,
+    [Parameter(Mandatory)] [string] $WorkflowDispatchRef,
+    [Parameter(Mandatory)] [string] $ToolVersions,
+    [Parameter(Mandatory)] [string] $PublishReleases
+)
+
+Import-Module (Join-Path $PSScriptRoot "github-api.psm1")
+
+function Get-WorkflowRunLink {
+    param(
+        [Parameter(Mandatory)] [object] $GitHubApi,
+        [Parameter(Mandatory)] [string] $WorkflowFileName,
+        [Parameter(Mandatory)] [string] $ToolVersion
+    )
+
+    $listWorkflowRuns = $GitHubApi.GetWorkflowRuns($WorkflowFileName).workflow_runs | Sort-Object -Property 'run_number' -Descending
+
+    foreach ($workflowRun in $listWorkflowRuns) {
+        $workflowRunJob = $gitHubApi.GetWorkflowRunJobs($workflowRun.id).jobs | Select-Object -First 1
+
+        if ($workflowRunJob.name -match $ToolVersion) {
+            return $workflowRun.html_url
+        }
+    }
+
+    return $null
+}
+
+function Queue-Builds {
+    param (
+        [Parameter(Mandatory)] [object] $GitHubApi,
+        [Parameter(Mandatory)] [string] $ToolVersions,
+        [Parameter(Mandatory)] [string] $WorkflowFileName,
+        [Parameter(Mandatory)] [string] $WorkflowDispatchRef,
+        [Parameter(Mandatory)] [string] $PublishReleases
+    )
+
+    $inputs = @{
+        PUBLISH_RELEASES = $PublishReleases
+    }
+    
+    $ToolVersions.Split(',') | ForEach-Object { 
+        $version = $_.Trim()
+        $inputs.VERSION = $version
+
+        Write-Host "Queue build for $version..."
+        $GitHubApi.CreateWorkflowDispatch($WorkflowFileName, $WorkflowDispatchRef, $inputs)
+
+        Start-Sleep -s 10
+        $workflowRunLink = Get-WorkflowRunLink -GitHubApi $GitHubApi `
+                                               -WorkflowFileName $WorkflowFileName `
+                                               -ToolVersion $version
+
+        if (-not $workflowRunLink) {
+            Write-Host "Could not find build for $version..."
+            exit 1
+        }
+
+        Write-Host "Link to the build: $workflowRunLink"
+    }
+}
+
+$gitHubApi = Get-GitHubApi -RepositoryFullName $RepositoryFullName -AccessToken $AccessToken
+
+Write-Host "Versions to build: $ToolVersions"
+Queue-Builds -GitHubApi $gitHubApi `
+             -ToolVersions $ToolVersions `
+             -WorkflowFileName $WorkflowFileName `
+             -WorkflowDispatchRef $WorkflowDispatchRef `
+             -PublishReleases $PublishReleases 

--- a/github/run-ci-builds.ps1
+++ b/github/run-ci-builds.ps1
@@ -81,7 +81,7 @@ function Queue-Builds {
     }
 }
 
-$gitHubApi = Get-GitHubApi -RepositoryFullName $RepositoryFullName -AccessToken $AccessToken
+$gitHubApi = Get-GitHubApi -RepositoryName $RepositoryFullName -AccessToken $AccessToken
 
 Write-Host "Versions to build: $ToolVersions"
 Queue-Builds -GitHubApi $gitHubApi `

--- a/packages-generation/manifest-generator.ps1
+++ b/packages-generation/manifest-generator.ps1
@@ -1,13 +1,10 @@
 <#
 .SYNOPSIS
 Generate versions manifest based on repository releases
-
 .DESCRIPTION
 Versions manifest is needed to find the latest assets for particular version of tool
-.PARAMETER GitHubRepositoryOwner
-Required parameter. The organization which tool repository belongs
-.PARAMETER GitHubRepositoryName
-Required parameter. The name of tool repository
+.PARAMETER RepositoryFullName
+Required parameter. The owner and repository name. For example, 'actions/versions-package-tools'
 .PARAMETER GitHubAccessToken
 Required parameter. PAT Token to overcome GitHub API Rate limit
 .PARAMETER OutputFile
@@ -17,8 +14,7 @@ Path to the json file with parsing configuration
 #>
 
 param (
-    [Parameter(Mandatory)] [string] $GitHubRepositoryOwner,
-    [Parameter(Mandatory)] [string] $GitHubRepositoryName,
+    [Parameter(Mandatory)] [string] $RepositoryFullName,
     [Parameter(Mandatory)] [string] $GitHubAccessToken,
     [Parameter(Mandatory)] [string] $OutputFile,
     [Parameter(Mandatory)] [string] $ConfigurationFile
@@ -29,7 +25,7 @@ Import-Module (Join-Path $PSScriptRoot "manifest-utils.psm1") -Force
 
 $configuration = Read-ConfigurationFile -Filepath $ConfigurationFile
 
-$gitHubApi = Get-GitHubApi -AccountName $GitHubRepositoryOwner -ProjectName $GitHubRepositoryName -AccessToken $GitHubAccessToken
+$gitHubApi = Get-GitHubApi -RepositoryFullName $RepositoryFullName -AccessToken $GitHubAccessToken
 $releases = $gitHubApi.GetReleases()
 $versionIndex = Build-VersionsManifest -Releases $releases -Configuration $configuration
 $versionIndex | ConvertTo-Json -Depth 5 | Out-File $OutputFile -Encoding UTF8NoBOM -Force

--- a/packages-generation/manifest-generator.ps1
+++ b/packages-generation/manifest-generator.ps1
@@ -25,7 +25,7 @@ Import-Module (Join-Path $PSScriptRoot "manifest-utils.psm1") -Force
 
 $configuration = Read-ConfigurationFile -Filepath $ConfigurationFile
 
-$gitHubApi = Get-GitHubApi -RepositoryName $RepositoryFullName -AccessToken $GitHubAccessToken
+$gitHubApi = Get-GitHubApi -RepositoryFullName $RepositoryFullName -AccessToken $GitHubAccessToken
 $releases = $gitHubApi.GetReleases()
 $versionIndex = Build-VersionsManifest -Releases $releases -Configuration $configuration
 $versionIndex | ConvertTo-Json -Depth 5 | Out-File $OutputFile -Encoding UTF8NoBOM -Force

--- a/packages-generation/manifest-generator.ps1
+++ b/packages-generation/manifest-generator.ps1
@@ -25,7 +25,7 @@ Import-Module (Join-Path $PSScriptRoot "manifest-utils.psm1") -Force
 
 $configuration = Read-ConfigurationFile -Filepath $ConfigurationFile
 
-$gitHubApi = Get-GitHubApi -RepositoryFullName $RepositoryFullName -AccessToken $GitHubAccessToken
+$gitHubApi = Get-GitHubApi -RepositoryName $RepositoryFullName -AccessToken $GitHubAccessToken
 $releases = $gitHubApi.GetReleases()
 $versionIndex = Build-VersionsManifest -Releases $releases -Configuration $configuration
 $versionIndex | ConvertTo-Json -Depth 5 | Out-File $OutputFile -Encoding UTF8NoBOM -Force

--- a/pester-extensions.psm1
+++ b/pester-extensions.psm1
@@ -4,6 +4,22 @@ Pester extension that allows to run command and validate exit code
 .EXAMPLE
 "python file.py" | Should -ReturnZeroExitCode
 #>
+
+function Get-CommandResult {
+    param (
+        [Parameter(Mandatory=$true)]
+        [string] $Command,
+        [switch] $Multiline
+    )
+    # Bash trick to suppress and show error output because some commands write to stderr (for example, "python --version")
+    $stdout = & bash -c "$Command 2>&1"
+    $exitCode = $LASTEXITCODE
+    return @{
+        Output = If ($Multiline -eq $true) { $stdout } else { [string]$stdout }
+        ExitCode = $exitCode
+    }
+}
+
 function ShouldReturnZeroExitCode {
     Param(
         [String] $ActualValue,

--- a/pester-extensions.psm1
+++ b/pester-extensions.psm1
@@ -6,28 +6,29 @@ Pester extension that allows to run command and validate exit code
 #>
 function ShouldReturnZeroExitCode {
     Param(
-        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()]
-        [String]$ActualValue,
-        [switch]$Negate
+        [String] $ActualValue,
+        [switch] $Negate,
+        [string] $Because # This parameter is unused by we need it to match Pester asserts signature
     )
 
-    Write-Host "Run command '${ActualValue}'"
-    Invoke-Expression -Command $ActualValue | ForEach-Object { Write-Host $_ }
-    $actualExitCode = $LASTEXITCODE
+    $result = Get-CommandResult $ActualValue
 
-    [bool]$succeeded = $actualExitCode -eq 0
+    [bool]$succeeded = $result.ExitCode -eq 0
     if ($Negate) { $succeeded = -not $succeeded }
 
     if (-not $succeeded)
     {
-        $failureMessage = "Command '${ActualValue}' has finished with exit code ${actualExitCode}"
+        $commandOutputIndent = " " * 4
+        $commandOutput = ($result.Output | ForEach-Object { "${commandOutputIndent}${_}" }) -join "`n"
+        $failureMessage = "Command '${ActualValue}' has finished with exit code ${actualExitCode}`n${commandOutput}"
     }
 
-    return New-Object PSObject -Property @{
+    return [PSCustomObject] @{
         Succeeded      = $succeeded
         FailureMessage = $failureMessage
     }
 }
 
-Add-AssertionOperator -Name ReturnZeroExitCode `
-                    -Test  $function:ShouldReturnZeroExitCode
+if (Get-Command -Name Add-AssertionOperator -ErrorAction SilentlyContinue) {
+    Add-AssertionOperator -Name ReturnZeroExitCode -InternalName ShouldReturnZeroExitCode -Test ${function:ShouldReturnZeroExitCode}
+}


### PR DESCRIPTION
We are working on moving our `actions/<tool>-versions` CI from the AzureDevOps to the GitHub actions. In scope of this PR we've updated `get-<tool>-versions` pipeline:
- we've created `github/run-ci-builds.ps1` script to trigger workflow runs
- we've updated the `github/github-api.psm1` script for this purpose
- we've switched `run-ci-builds-steps.yml` file to use the `github/run-ci-builds.ps1` script

We've also updated scripts to pass parameter contains full repository name to the `github-api.psm1` script.