### PR TITLE
Add GetToolDirectory function and fix Get-CommandResult to work properly on Windows

### DIFF
--- a/common-helpers.psm1
+++ b/common-helpers.psm1
@@ -104,7 +104,5 @@ function GetToolDirectory {
     }
     $ToolcachePath = Join-Path -Path $targetPath -ChildPath $ToolName
     $ToolcacheVersionPath = Join-Path -Path $ToolcachePath -ChildPath $Version
-    $toolDirectory = Join-Path $ToolcacheVersionPath $Architecture
-
-    return $toolDirectory
+    return Join-Path $ToolcacheVersionPath $Architecture
 }

--- a/common-helpers.psm1
+++ b/common-helpers.psm1
@@ -83,3 +83,28 @@ function IsNixPlatform {
 
     return ($Platform -match "macos") -or ($Platform -match "darwin") -or ($Platform -match "ubuntu") -or ($Platform -match "linux")
 }
+
+<#
+.SYNOPSIS
+Get root directory of selected tool
+#>
+function GetToolDirectory {
+    param(
+        [Parameter(Mandatory=$true)]
+        [String]$ToolName,
+        [Parameter(Mandatory=$true)]
+        [String]$Version,
+        [Parameter(Mandatory=$true)]
+        [String]$Architecture
+    )
+    $targetPath = $env:AGENT_TOOLSDIRECTORY
+    if ([string]::IsNullOrEmpty($targetPath)) {
+        # GitHub Windows images don't have `AGENT_TOOLSDIRECTORY` variable
+        $targetPath = $env:RUNNER_TOOL_CACHE
+    }
+    $ToolcachePath = Join-Path -Path $targetPath -ChildPath $ToolName
+    $ToolcacheVersionPath = Join-Path -Path $ToolcachePath -ChildPath $Version
+    $toolDirectory = Join-Path $ToolcacheVersionPath $Architecture
+
+    return $toolDirectory
+}

--- a/pester-extensions.psm1
+++ b/pester-extensions.psm1
@@ -13,14 +13,14 @@ function Get-CommandResult {
     )
     # CMD and bash trick to suppress and show error output because some commands write to stderr (for example, "python --version")
     If ($IsWindows) {
-        $output = & $env:comspec /c "$Command 2>&1"
+        $stdout = & $env:comspec /c "$Command 2>&1"
     } else {
-        $output = & bash -c "$Command 2>&1"
+        $stdout = & bash -c "$Command 2>&1"
     }
     $exitCode = $LASTEXITCODE
 
     return @{
-        Output = If ($Multiline -eq $true) { $output } else { [string]$output }
+        Output = If ($Multiline -eq $true) { $stdout } else { [string]$stdout }
         ExitCode = $exitCode
     }
 }

--- a/pester-extensions.psm1
+++ b/pester-extensions.psm1
@@ -11,9 +11,9 @@ function Get-CommandResult {
         [string] $Command,
         [switch] $Multiline
     )
-    # CMD trick to suppress and show error output because some commands write to stderr (for example, "python --version")
+    # CMD and bash trick to suppress and show error output because some commands write to stderr (for example, "python --version")
     If ($IsWindows) {
-        [string[]]$output = & $env:comspec /c "$Command 2>&1"
+        $output = & $env:comspec /c "$Command 2>&1"
     } else {
         $output = & bash -c "$Command 2>&1"
     }
@@ -27,7 +27,7 @@ function Get-CommandResult {
 
 function ShouldReturnZeroExitCode {
     Param(
-        [string] $ActualValue,
+        [String] $ActualValue,
         [switch] $Negate,
         [string] $Because # This parameter is unused by we need it to match Pester asserts signature
     )

--- a/pester-extensions.psm1
+++ b/pester-extensions.psm1
@@ -6,23 +6,28 @@ Pester extension that allows to run command and validate exit code
 #>
 
 function Get-CommandResult {
-    param (
+    Param (
         [Parameter(Mandatory=$true)]
         [string] $Command,
         [switch] $Multiline
     )
-    # Bash trick to suppress and show error output because some commands write to stderr (for example, "python --version")
-    $stdout = & bash -c "$Command 2>&1"
+    # CMD trick to suppress and show error output because some commands write to stderr (for example, "python --version")
+    If ($IsWindows) {
+        [string[]]$output = & $env:comspec /c "$Command 2>&1"
+    } else {
+        $output = & bash -c "$Command 2>&1"
+    }
     $exitCode = $LASTEXITCODE
+
     return @{
-        Output = If ($Multiline -eq $true) { $stdout } else { [string]$stdout }
+        Output = If ($Multiline -eq $true) { $output } else { [string]$output }
         ExitCode = $exitCode
     }
 }
 
 function ShouldReturnZeroExitCode {
     Param(
-        [String] $ActualValue,
+        [string] $ActualValue,
         [switch] $Negate,
         [string] $Because # This parameter is unused by we need it to match Pester asserts signature
     )

--- a/win-vs-env.psm1
+++ b/win-vs-env.psm1
@@ -3,7 +3,7 @@
 ###
 
 function Get-VSWhere {
-    $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe";
+    $vswhere = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
 
     if (-not (Test-Path $vswhere )) {
         [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
@@ -34,9 +34,11 @@ function Invoke-Environment
 }
 
 function Get-VSInstallationPath {
+    Write-Host "ProgramFiles(x86) - ${env:ProgramFiles(x86)}"
     $vswhere = Get-VSWhere
+    Write-Host "vswhere - $vswhere"
     $installationPath = & $vswhere -prerelease -legacy -latest -property installationPath
-
+    Write-Host "installationPath - $installationPath"
     return $installationPath
 }
 

--- a/win-vs-env.psm1
+++ b/win-vs-env.psm1
@@ -3,7 +3,7 @@
 ###
 
 function Get-VSWhere {
-    $vswhere = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
+    $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe";
 
     if (-not (Test-Path $vswhere )) {
         [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
@@ -34,11 +34,9 @@ function Invoke-Environment
 }
 
 function Get-VSInstallationPath {
-    Write-Host "ProgramFiles(x86) - ${env:ProgramFiles(x86)}"
     $vswhere = Get-VSWhere
-    Write-Host "vswhere - $vswhere"
     $installationPath = & $vswhere -prerelease -legacy -latest -property installationPath
-    Write-Host "installationPath - $installationPath"
+
     return $installationPath
 }
 


### PR DESCRIPTION
We are working on moving our `actions/boost-versions` CI from the AzureDevOps to the GitHub actions. In scope of this PR we've updated `pester-extensions.psm1` and added _GetToolDirectory_ function to `common-helpers.psm1`  for work with Windows 