### PR TITLE
Add xamarin tool version check

### DIFF
--- a/azure-pipelines/get-tool-versions-xamarin.yml
+++ b/azure-pipelines/get-tool-versions-xamarin.yml
@@ -1,0 +1,37 @@
+name: $(date:yyyyMMdd)$(rev:.r)
+trigger: none
+pr: none
+schedules:
+- cron: "0 8 * * Thu"
+  displayName: Daily build
+  branches:
+    include:
+    - main
+  always: true
+
+variables:
+  PoolName: 'Azure Pipelines'
+  VmImage: 'ubuntu-18.04'
+
+stages:
+- stage: Find_New_Versions
+  dependsOn: []
+  jobs:
+  - job: Find_New_Versions
+    pool:
+      name: $(PoolName)
+      vmImage: $(VmImage)
+    steps:
+    - template: /azure-pipelines/templates/get-tool-versions-steps.yml
+
+- stage: Check_New_Versions
+  dependsOn: Find_New_Versions
+  jobs:
+  - job: Check_New_Versions
+    pool:
+      name: $(PoolName)
+      vmImage: $(VmImage)
+    variables:
+      ToolVersions: $[ stageDependencies.Find_New_Versions.Find_New_Versions.outputs['Get_versions.TOOL_VERSIONS'] ]
+    steps:
+    - template: /azure-pipelines/templates/check-versions.yml

--- a/azure-pipelines/templates/check-versions.yml
+++ b/azure-pipelines/templates/check-versions.yml
@@ -21,7 +21,7 @@ steps:
     TargetType: inline
     script: |
       $ToolName = "$(TOOL_NAME)"
-      if ($ToolName -in @("Python", "Xamarin") {
+      if ($ToolName -in @("Python", "Xamarin")) {
         $PipelineUrl = " "
       } else {
         $PipelineUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"

--- a/azure-pipelines/templates/check-versions.yml
+++ b/azure-pipelines/templates/check-versions.yml
@@ -21,7 +21,7 @@ steps:
     TargetType: inline
     script: |
       $ToolName = "$(TOOL_NAME)"
-      if ($ToolName -eq "Python") {
+      if ($ToolName -in @("Python", "Xamarin") {
         $PipelineUrl = " "
       } else {
         $PipelineUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"
@@ -36,7 +36,7 @@ steps:
       $newBuildName = "[FOUND] $(Build.BuildNumber)"
       Write-Host "##vso[build.updatebuildnumber]$newBuildName"
 
-- task: PowerShell@2	
+- task: PowerShell@2
   displayName: 'Send Slack notification'
   inputs:
     targetType: filePath

--- a/get-new-tool-versions/get-new-tool-versions.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.ps1
@@ -18,10 +18,10 @@ $VersionsFromManifest = $ToolVersionParser.GetUploadedVersions()
 
 $joinChars = ", "
 if ($ToolName -eq "Xamarin") {
-    $VersionsToBuild = $VersionsFromDist | Where-Object { $VersionsFromManifest[$_.name] -notcontains $_.version } | ForEach-Object {
+    $VersionsToBuild = $VersionsFromDist | Where-Object { $VersionsFromManifest[$_.name] -notcontains $_.version } | ForEach-Object {[string]::Empty} {
         '{0,-15} : {1}' -f $_.name, $_.version
     }
-    $joinChars = "\n"
+    $joinChars = "\n\t"
 } else {
     $VersionsToBuild = $VersionsFromDist | Where-Object { $VersionsFromManifest -notcontains $_ }
 }

--- a/get-new-tool-versions/get-new-tool-versions.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.ps1
@@ -3,7 +3,7 @@
 Check and return list of new available tool versions
 
 .PARAMETER ToolName
-Required parameter. The name of tool for which parser is available (Node, Go, Python)
+Required parameter. The name of tool for which parser is available (Node, Go, Python, Xamarin)
 #>
 
 param (
@@ -16,10 +16,18 @@ $ToolVersionParser = Get-ToolVersionsParser -ToolName $ToolName
 $VersionsFromDist = $ToolVersionParser.GetAvailableVersions()
 $VersionsFromManifest = $ToolVersionParser.GetUploadedVersions()
 
-$VersionsToBuild = $VersionsFromDist | Where-Object { $VersionsFromManifest -notcontains $_ }
+$joinChars = ", "
+if ($ToolName -eq "Xamarin") {
+    $VersionsToBuild = $VersionsFromDist | Where-Object { $VersionsFromManifest[$_.name] -notcontains $_.version } | ForEach-Object {
+        '{0,-15} : {1}' -f $_.name, $_.version
+    }
+    $joinChars = "\n"
+} else {
+    $VersionsToBuild = $VersionsFromDist | Where-Object { $VersionsFromManifest -notcontains $_ }
+}
 
 if ($VersionsToBuild) {
-    $availableVersions = $VersionsToBuild -join ", "
+    $availableVersions = $VersionsToBuild -join $joinChars
     Write-Host "The following versions are available to build:`n${availableVersions}"
     Write-Host "##vso[task.setvariable variable=TOOL_VERSIONS;isOutput=true]${availableVersions}"
 } else {

--- a/get-new-tool-versions/parsers/parsers-factory.psm1
+++ b/get-new-tool-versions/parsers/parsers-factory.psm1
@@ -1,6 +1,7 @@
 using module "./node-parser.psm1"
 using module "./go-parser.psm1"
 using module "./python-parser.psm1"
+using module "./xamarin-parser.psm1"
 
 function Get-ToolVersionsParser {
     param(
@@ -12,6 +13,7 @@ function Get-ToolVersionsParser {
         "Node" { return [NodeVersionsParser]::New() }
         "Go" { return [GoVersionsParser]::New() }
         "Python" { return [PythonVersionsParser]::New() }
+        "Xamarin" { return [XamarinversionsParser]::New() }
         Default {
             throw "Unknown tool name"
         }

--- a/get-new-tool-versions/parsers/xamarin-parser.psm1
+++ b/get-new-tool-versions/parsers/xamarin-parser.psm1
@@ -1,0 +1,30 @@
+using module "./base-parser.psm1"
+
+class XamarinVersionsParser: BaseVersionsParser {
+    [PSCustomObject] GetAvailableVersions() {
+        $allVersions = $this.ParseAllAvailableVersions()
+        return $allVersions
+    }
+
+    [hashtable] GetUploadedVersions() {
+        $url = $this.BuildGitHubFileUrl("actions", "virtual-environments", "main", "images/macos/toolsets/toolset-11.0.json")
+        $releases = Invoke-RestMethod $url -MaximumRetryCount $this.ApiRetryCount -RetryIntervalSec $this.ApiRetryIntervalSeconds
+        $xamarin = $releases.xamarin
+        $xamarinReleases = @{
+            'Mono Framework' = $xamarin.'mono-versions'
+            'Xamarin.Android' = $xamarin.'android-versions'
+            'Xamarin.iOS' = $xamarin.'ios-versions'
+            'Xamarin.Mac' = $xamarin.'mac-versions'
+        }
+        return $xamarinReleases
+    }
+
+    hidden [PSCustomObject] ParseAllAvailableVersions() {
+        $url = "http://aka.ms/manifest/stable"
+        $filteredProducts = @('Mono Framework', 'Xamarin.Android', 'Xamarin.iOS', 'Xamarin.Mac')
+        $releases = Invoke-RestMethod $url -MaximumRetryCount $this.ApiRetryCount -RetryIntervalSec $this.ApiRetryIntervalSeconds
+        $items = $releases.items
+        $products = $items | Where-Object {$_.name -in $filteredProducts} | Sort-Object name | Select-Object name, version
+        return $products
+    }
+}

--- a/get-new-tool-versions/send-slack-notification.ps1
+++ b/get-new-tool-versions/send-slack-notification.ps1
@@ -35,7 +35,11 @@ param(
 Import-Module $PSScriptRoot/helpers.psm1 -DisableNameChecking
 
 # Create JSON body
-$text = "The following versions of '$toolName' are available, consider adding them to toolset: $toolVersion"
+if ($toolName -eq "Xamarin") {
+    $text = "The following versions of '$toolName' are available, consider adding them to toolset: $toolVersion"
+} else {
+    $text = "The following versions of '$toolName' are available to upload: $toolVersion"
+}
 if (-not ([string]::IsNullOrWhiteSpace($PipelineUrl))) {
     $text += "\nLink to the pipeline: $pipelineUrl"
 }

--- a/get-new-tool-versions/send-slack-notification.ps1
+++ b/get-new-tool-versions/send-slack-notification.ps1
@@ -35,7 +35,7 @@ param(
 Import-Module $PSScriptRoot/helpers.psm1 -DisableNameChecking
 
 # Create JSON body
-$text = "The following versions of '$toolName' are available to upload: $toolVersion"
+$text = "The following versions of '$toolName' are available, consider adding them to toolset: $toolVersion"
 if (-not ([string]::IsNullOrWhiteSpace($PipelineUrl))) {
     $text += "\nLink to the pipeline: $pipelineUrl"
 }


### PR DESCRIPTION
- Run only on Tuesdays
- Checks 'Mono Framework', 'Xamarin.Android', 'Xamarin.iOS', 'Xamarin.Mac' from `http://aka.ms/manifest/stable` site
- Comparing with `https://github.com/actions/virtual-environments/blob/main/images/macos/toolsets/toolset-11.0.json`

Example:
![image](https://user-images.githubusercontent.com/47745270/111783911-c9c80680-88cb-11eb-916f-1a01063f22d7.png)

