### PR TITLE
Rename toolset for macOS Big Sur

### DIFF
--- a/get-new-tool-versions/parsers/xamarin-parser.psm1
+++ b/get-new-tool-versions/parsers/xamarin-parser.psm1
@@ -7,7 +7,7 @@ class XamarinVersionsParser: BaseVersionsParser {
     }
 
     [hashtable] GetUploadedVersions() {
-        $url = $this.BuildGitHubFileUrl("actions", "virtual-environments", "main", "images/macos/toolsets/toolset-11.0.json")
+        $url = $this.BuildGitHubFileUrl("actions", "virtual-environments", "main", "images/macos/toolsets/toolset-11.json")
         $releases = Invoke-RestMethod $url -MaximumRetryCount $this.ApiRetryCount -RetryIntervalSec $this.ApiRetryIntervalSeconds
         $xamarin = $releases.xamarin
         $xamarinReleases = @{


### PR DESCRIPTION
Rename `toolset-11.0.json` -> `toolset-11.json` related to  this https://github.com/actions/virtual-environments/pull/3417 PR .