### PR TITLE
Add generic support for LTS rules

### DIFF
--- a/node-manifest-config.json
+++ b/node-manifest-config.json
@@ -1,8 +1,0 @@
-{
-    "regex": "node-\\d+\\.\\d+\\.\\d+-(\\w+)-(x\\d+)",
-    "groups": {
-        "arch": 2,
-        "platform": 1
-    },
-    "lts_rule_expression": "(Invoke-RestMethod 'https://raw.githubusercontent.com/nodejs/Release/main/schedule.json').PSObject.Properties | Where-Object { $_.Value.codename } | ForEach-Object { @{ Name = $_.Name.TrimStart('v'); Value = $_.Value.codename } }"
-}

--- a/node-manifest-config.json
+++ b/node-manifest-config.json
@@ -1,0 +1,8 @@
+{
+    "regex": "node-\\d+\\.\\d+\\.\\d+-(\\w+)-(x\\d+)",
+    "groups": {
+        "arch": 2,
+        "platform": 1
+    },
+    "lts_rule_expression": "(Invoke-RestMethod 'https://raw.githubusercontent.com/nodejs/Release/main/schedule.json').PSObject.Properties | Where-Object { $_.Value.codename } | ForEach-Object { @{ Name = $_.Name.TrimStart('v'); Value = $_.Value.codename } }"
+}

--- a/packages-generation/manifest-utils.psm1
+++ b/packages-generation/manifest-utils.psm1
@@ -72,7 +72,9 @@ function Build-VersionsManifest {
         $versionHash = [PSCustomObject]@{}
         $versionHash | Add-Member -Name "version" -Value $versionKey -MemberType NoteProperty
         $versionHash | Add-Member -Name "stable" -Value $stable -MemberType NoteProperty
-        if ($ltsStatus) { $versionHash | Add-Member -Name "lts" -Value $ltsStatus -MemberType NoteProperty }
+        if ($ltsStatus) {
+            $versionHash | Add-Member -Name "lts" -Value $ltsStatus -MemberType NoteProperty
+        }
         $versionHash | Add-Member -Name "release_url" -Value $release.html_url -MemberType NoteProperty
         $versionHash | Add-Member -Name "files" -Value $releaseAssets -MemberType NoteProperty
         $versionsHash.Add($versionKey, $versionHash)
@@ -108,5 +110,4 @@ function Get-VersionLtsStatus {
     }
 
     return $null
-
 }

--- a/packages-generation/manifest-utils.psm1
+++ b/packages-generation/manifest-utils.psm1
@@ -110,7 +110,3 @@ function Get-VersionLtsStatus {
     return $null
 
 }
-
-# Invoke-RestMethod "https://raw.githubusercontent.com/nodejs/Release/main/schedule.json"
-# $arr.PSObject.Properties | Where-Object { $_.Value.codename } | ForEach-Object { @( @{ $_.Name = $_.Value.codename }) }
-# (Invoke-RestMethod 'https://raw.githubusercontent.com/nodejs/Release/main/schedule.json').PSObject.Properties | Where-Object { $_.Value.codename } | ForEach-Object { @{ Name = $_.Name.TrimStart('v'); Value = $_.Value.codename } }


### PR DESCRIPTION
### Context
We need to add new additional property for Node.js versions-manifest.json to show lts title based on https://raw.githubusercontent.com/nodejs/Release/main/schedule.json

We shouldn't implement any node-specific logic on manifest-generator level because we need to keep it generic.
I have decided to add support for custom expressions on config level.

### How it works
Manifest generator imports `lts_rule_expression` from config, run it and use expression result as a source of rules for LTS decision

### Drawbacks
It is not super convenient to keep PowerShell expression as a JSON property but it will allow us to stay generic.

### How Node.js config will look like
```json
{
    "regex": "node-\\d+\\.\\d+\\.\\d+-(\\w+)-(x\\d+)",
    "groups": {
        "arch": 2,
        "platform": 1
    },
    "lts_rule_expression": "(Invoke-RestMethod 'https://raw.githubusercontent.com/nodejs/Release/main/schedule.json').PSObject.Properties | Where-Object { $_.Value.codename } | ForEach-Object { @{ Name = $_.Name.TrimStart('v'); Value = $_.Value.codename } }"
}
```