### PR TITLE
Changes for moving get-go-versions pipeline to go-versions repository

### DIFF
--- a/get-new-tool-versions/get-new-tool-versions.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.ps1
@@ -29,7 +29,11 @@ if ($ToolName -eq "Xamarin") {
 if ($VersionsToBuild) {
     $availableVersions = $VersionsToBuild -join $joinChars
     Write-Host "The following versions are available to build:`n${availableVersions}"
-    Write-Host "##vso[task.setvariable variable=TOOL_VERSIONS;isOutput=true]${availableVersions}"
+    if ($ToolName -eq "Go") {
+        Write-Host "::set-output name=version_number::${availableVersions}"
+    } else {
+        Write-Host "##vso[task.setvariable variable=TOOL_VERSIONS;isOutput=true]${availableVersions}"
+    }
 } else {
     Write-Host "There aren't versions to build"
 }

--- a/github/github-api.psm1
+++ b/github/github-api.psm1
@@ -124,6 +124,11 @@ class GitHubApi
         }
     }
 
+    [void] CancelWorkflow([string]$WorkflowId) {
+        $url = "actions/runs/$WorkflowId/cancel"
+        $this.InvokeRestMethod($url, 'POST', $null, $null)
+    }
+
     [object] hidden InvokeRestMethod(
         [string] $Url,
         [string] $Method,


### PR DESCRIPTION
We are moving get-go-versions pipeline from Azure DevOps to go-versions repository. For the workflow to work properly, we must add CancelWorkflow method to `github-api.psm1` and update setting of `availableVersions` variable in `get-new-tool-versions.ps1`.

Related work item: https://github.com/actions/virtual-environments-internal/issues/2412