### PR TITLE
Move get-xamarin-versions pipeline from Azure DevOps

### DIFF
--- a/.github/workflows/get-xamarin-versions.yml
+++ b/.github/workflows/get-xamarin-versions.yml
@@ -1,0 +1,68 @@
+name: Get Xamarin versions
+on:
+  schedule:
+    - cron: '0 8 * * THU'
+  workflow_dispatch:
+
+env:
+  TOOL_NAME: "Xamarin"
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  find_new_versions:
+    name: Find new versions
+    runs-on: ubuntu-latest
+    outputs:
+      versions_output: ${{ steps.Get_new_versions.outputs.TOOL_VERSIONS }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - id: Get_new_versions
+        name: Get new versions
+        run: ./get-new-tool-versions/get-new-tool-versions.ps1 -ToolName ${{ env.TOOL_NAME }}
+
+  check_new_versions:
+    name: Check new versions
+    runs-on: ubuntu-latest
+    needs: find_new_versions
+    env:
+      TOOL_VERSIONS: ${{needs.find_new_versions.outputs.versions_output}}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check Versions
+        if: success() && env.TOOL_VERSIONS == ''
+        run: |
+          Write-Host "No new versions were found"
+          Import-Module "./github/github-api.psm1"
+          $gitHubApi = Get-GitHubApi -RepositoryFullName "$env:GITHUB_REPOSITORY" `
+                                     -AccessToken "${{ secrets.GITHUB_TOKEN }}"
+
+          $gitHubApi.CancelWorkflow("$env:GITHUB_RUN_ID")
+          Start-Sleep -Seconds 60
+
+      - name: Send Slack notification
+        run: |
+          ./get-new-tool-versions/send-slack-notification.ps1 -Url "${{ secrets.SLACK_CHANNEL_URL }}" `
+                                                                      -ToolName "${{ env.TOOL_NAME }}" `
+                                                                      -ToolVersion "${{ env.TOOL_VERSIONS }}" `
+                                                                      -ImageUrl "https://avatars.githubusercontent.com/u/790012?s=200&v=4"
+
+  check_build:
+    name: Check build for failures 
+    runs-on: ubuntu-latest
+    needs: [find_new_versions, check_new_versions]
+    if: failure()
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Send Slack notification if build fails
+        run: |
+          $pipelineUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
+          $Message = "The build of the '${{ env.TOOL_NAME }}' detection pipeline failed :progress-error:\nLink to the pipeline: $pipelineUrl"
+          ./get-new-tool-versions/send-slack-notification.ps1 -Url "${{ secrets.SLACK_CHANNEL_URL }}" `
+                                                                      -ToolName "${{ env.TOOL_NAME }}" `
+                                                                      -Text "$Message" `
+                                                                      -ImageUrl "https://avatars.githubusercontent.com/u/790012?s=200&v=4"

--- a/get-new-tool-versions/get-new-tool-versions.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.ps1
@@ -29,7 +29,11 @@ if ($ToolName -eq "Xamarin") {
 if ($VersionsToBuild) {
     $availableVersions = $VersionsToBuild -join $joinChars
     Write-Host "The following versions are available to build:`n${availableVersions}"
-    Write-Host "##vso[task.setvariable variable=TOOL_VERSIONS;isOutput=true]${availableVersions}"
+    if ($ToolName -eq "Go") {
+        Write-Host "::set-output name=version_number::${availableVersions}"
+    } else {
+        Write-Host "##vso[task.setvariable variable=TOOL_VERSIONS;isOutput=true]${availableVersions}"
+    }
 } else {
     Write-Host "There aren't versions to build"
 }

--- a/get-new-tool-versions/get-new-tool-versions.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.ps1
@@ -29,11 +29,8 @@ if ($ToolName -eq "Xamarin") {
 if ($VersionsToBuild) {
     $availableVersions = $VersionsToBuild -join $joinChars
     Write-Host "The following versions are available to build:`n${availableVersions}"
-    if ($ToolName -eq "Go") {
-        Write-Host "::set-output name=version_number::${availableVersions}"
-    } else {
-        Write-Host "##vso[task.setvariable variable=TOOL_VERSIONS;isOutput=true]${availableVersions}"
-    }
+    Write-Host "::set-output name=version_number::${availableVersions}"
+    Write-Host "##vso[task.setvariable variable=TOOL_VERSIONS;isOutput=true]${availableVersions}"
 } else {
     Write-Host "There aren't versions to build"
 }

--- a/get-new-tool-versions/get-new-tool-versions.ps1
+++ b/get-new-tool-versions/get-new-tool-versions.ps1
@@ -29,7 +29,7 @@ if ($ToolName -eq "Xamarin") {
 if ($VersionsToBuild) {
     $availableVersions = $VersionsToBuild -join $joinChars
     Write-Host "The following versions are available to build:`n${availableVersions}"
-    Write-Host "::set-output name=version_number::${availableVersions}"
+    Write-Host "::set-output name=TOOL_VERSIONS::${availableVersions}"
     Write-Host "##vso[task.setvariable variable=TOOL_VERSIONS;isOutput=true]${availableVersions}"
 } else {
     Write-Host "There aren't versions to build"

--- a/get-new-tool-versions/send-slack-notification.ps1
+++ b/get-new-tool-versions/send-slack-notification.ps1
@@ -7,11 +7,13 @@ Required parameter. Incoming Webhook URL to post a message
 .PARAMETER ToolName
 Required parameter. The name of tool
 .PARAMETER ToolVersion
-Required parameter. Specifies the version of tool
+Optional parameter. Specifies the version of tool
 .PARAMETER PipelineUrl
-Required parameter. The pipeline URL
+Optional parameter. The pipeline URL
 .PARAMETER ImageUrl
 Optional parameter. The image URL
+.PARAMETER Text
+Optional parameter. The message to post
 #>
 
 param(
@@ -23,25 +25,25 @@ param(
     [ValidateNotNullOrEmpty()]
     [System.String]$ToolName,
 
-    [Parameter(Mandatory)]
-    [ValidateNotNullOrEmpty()]
     [System.String]$ToolVersion,
-
     [System.String]$PipelineUrl,
-    [System.String]$ImageUrl = 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png'
+    [System.String]$ImageUrl = 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png',
+    [System.String]$Text
 )
 
 # Import helpers module
 Import-Module $PSScriptRoot/helpers.psm1 -DisableNameChecking
 
 # Create JSON body
-if ($toolName -eq "Xamarin") {
-    $text = "The following versions of '$toolName' are available, consider adding them to toolset: $toolVersion"
-} else {
-    $text = "The following versions of '$toolName' are available to upload: $toolVersion"
-}
-if (-not ([string]::IsNullOrWhiteSpace($PipelineUrl))) {
-    $text += "\nLink to the pipeline: $pipelineUrl"
+if ([string]::IsNullOrWhiteSpace($Text)) {
+    if ($toolName -eq "Xamarin") {
+        $Text = "The following versions of '$toolName' are available, consider adding them to toolset: $toolVersion"
+    } else {
+        $Text = "The following versions of '$toolName' are available to upload: $toolVersion"
+    }
+    if (-not ([string]::IsNullOrWhiteSpace($PipelineUrl))) {
+        $Text += "\nLink to the pipeline: $pipelineUrl"
+    }
 }
 $jsonBodyMessage = @"
 {
@@ -50,7 +52,7 @@ $jsonBodyMessage = @"
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "$text"
+                "text": "$Text"
             },
             "accessory": {
                 "type": "image",

--- a/github/github-api.psm1
+++ b/github/github-api.psm1
@@ -124,6 +124,11 @@ class GitHubApi
         }
     }
 
+    [void] CancelWorkflow([string]$WorkflowId) {
+        $url = "actions/runs/$WorkflowId/cancel"
+        $this.InvokeRestMethod($url, 'POST', $null, $null)
+    }
+
     [object] hidden InvokeRestMethod(
         [string] $Url,
         [string] $Method,


### PR DESCRIPTION
In scope of this PR we moved [get-xamarin-versions](https://github.visualstudio.com/virtual-environments/_apps/hub/ms.vss-build-web.ci-designer-hub?pipelineId=96&nonce=u5jVuuk%2BCVrDm3aJt2TAgA%3D%3D&branch=main) pipeline from Azure DevOps to this repository.

Work item: actions/virtual-environments-internal#2412