### PR TITLE
Add retry strategy during manifest download for Validate manifest workflow runs

### DIFF
--- a/packages-generation/manifest-validator.ps1
+++ b/packages-generation/manifest-validator.ps1
@@ -40,7 +40,7 @@ function Test-DownloadUrl {
 
 Write-Host "Downloading manifest json from '$ManifestUrl'..."
 try {
-    $manifestResponse = Invoke-WebRequest -Method Get -Uri $ManifestUrl -Headers $webRequestHeaders
+    $manifestResponse = Invoke-WebRequest -Method Get -Uri $ManifestUrl -Headers $webRequestHeaders -MaximumRetryCount 5 -RetryIntervalSec 10
 } catch {
     Publish-Error "Unable to download manifest json from '$ManifestUrl'" $_
     exit 1


### PR DESCRIPTION
# Description
This PR adds retry strategy during manifest download for Validate manifest workflow runs. 

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/2800

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated