### PR TITLE
Change way for versions-manifest.json gathering for Validate manifest workflow runs

### DIFF
--- a/packages-generation/manifest-validator.ps1
+++ b/packages-generation/manifest-validator.ps1
@@ -1,5 +1,5 @@
 param (
-    [Parameter(Mandatory)][string] $ManifestUrl,
+    [Parameter(Mandatory)][string] $ManifestPath,
     [string] $AccessToken
 )
 
@@ -38,19 +38,16 @@ function Test-DownloadUrl {
     }
 }
 
-Write-Host "Downloading manifest json from '$ManifestUrl'..."
-try {
-    $manifestResponse = Invoke-WebRequest -Method Get -Uri $ManifestUrl -Headers $webRequestHeaders -MaximumRetryCount 5 -RetryIntervalSec 10
-} catch {
-    Publish-Error "Unable to download manifest json from '$ManifestUrl'" $_
+if (-not (Test-Path $ManifestPath)) {
+    Publish-Error "Unable to find manifest json file at '$ManifestPath'"
     exit 1
 }
 
-Write-Host "Parsing manifest json content from '$ManifestUrl'..."
+Write-Host "Parsing manifest json content from '$ManifestPath'..."
 try {
-    $manifestJson = $manifestResponse.Content | ConvertFrom-Json
+    $manifestJson = $( Get-Content $ManifestPath ) | ConvertFrom-Json
 } catch {
-    Publish-Error "Unable to parse manifest json content '$ManifestUrl'" $_
+    Publish-Error "Unable to parse manifest json content '$ManifestPath'" $_
     exit 1
 }
 


### PR DESCRIPTION
# Description
This PR changes logic of versions-manifest.json gathering for Validate manifest workflow runs. It allows usage of already synced up file instead of new one downloading by url. 

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/2800

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated