### PR TITLE
Remove Access Token usage

### DIFF
--- a/packages-generation/manifest-validator.ps1
+++ b/packages-generation/manifest-validator.ps1
@@ -1,6 +1,5 @@
 param (
-    [Parameter(Mandatory)][string] $ManifestPath,
-    [string] $AccessToken
+    [Parameter(Mandatory)][string] $ManifestPath
 )
 
 $Global:validationFailed = $false
@@ -10,7 +9,7 @@ function Publish-Error {
         [string] $ErrorDescription,
         [object] $Exception
     )
-    
+
     Write-Output "::error ::$ErrorDescription" 
     if (-not [string]::IsNullOrEmpty($Exception))
     {
@@ -20,12 +19,11 @@ function Publish-Error {
 }
 
 function Test-DownloadUrl {
-    param([string] $DownloadUrl)    
+    param(
+        [string] $DownloadUrl
+    )
+
     $request = [System.Net.WebRequest]::Create($DownloadUrl)
-    if ($AccessToken) {
-        $authorizationHeaderValue = "Basic $AccessToken"
-        $request.Headers.Add("Authorization", $authorizationHeaderValue)
-    }
     try {
         $response = $request.GetResponse()
         return ([int]$response.StatusCode -eq 200)


### PR DESCRIPTION
# Description
This PR removes Access Token usage from manifest-validator.ps1 script. It isn't required for current implementation.

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/2800
####  Validation build: https://github.com/nikolai-frolov/go-versions/actions/runs/1337554989

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated