### PR TITLE
Get only LTS Node versions from node-versions manifest file

### DIFF
--- a/get-new-tool-versions/parsers/verify-added-to-image/verify-common-tool-parser.psm1
+++ b/get-new-tool-versions/parsers/verify-added-to-image/verify-common-tool-parser.psm1
@@ -11,7 +11,7 @@ function Search-ToolsVersionsNotOnImage {
         if ($ToolName -eq "Node") {
             if ($_.lts) {
               $_.$FilterParameter.split(".")[0] + ".0"
-            } else { return }
+            }
         } else {
             $_.$FilterParameter.split(".")[0,1] -join"."
         }

--- a/get-new-tool-versions/parsers/verify-added-to-image/verify-common-tool-parser.psm1
+++ b/get-new-tool-versions/parsers/verify-added-to-image/verify-common-tool-parser.psm1
@@ -8,8 +8,10 @@ function Search-ToolsVersionsNotOnImage {
     
     $stableReleases = (Invoke-RestMethod $ReleasesUrl) | Where-Object stable -eq $true
     $stableReleaseVersions = $stableReleases | ForEach-Object {
-        if ($ToolName -eq "Node") { 
-            $_.$FilterParameter.split(".")[0] + ".0"
+        if ($ToolName -eq "Node") {
+            if ($_.lts) {
+              $_.$FilterParameter.split(".")[0] + ".0"
+            } else { return }
         } else {
             $_.$FilterParameter.split(".")[0,1] -join"."
         }


### PR DESCRIPTION
Internal issue: [link](https://github.com/actions/virtual-environments-internal/issues/3667)

Added condition to get only LTS Node versions from [node-versions repository](https://github.com/actions/node-versions/blob/main/versions-manifest.json)

Test run: https://github.com/vsafonkin/versions-package-tools/actions/runs/2239196913