### PR TITLE
Change macOS toolset to version 12

### DIFF
--- a/get-new-tool-versions/parsers/verify-added-to-image/verify-xamarin-parser.psm1
+++ b/get-new-tool-versions/parsers/verify-added-to-image/verify-xamarin-parser.psm1
@@ -6,7 +6,7 @@ function Search-XamarinVersionsNotOnImage {
 
     $xamarinReleases = (Invoke-RestMethod $ReleasesUrl).items
     $filteredReleases = $xamarinReleases | Where-Object {$_.name -in $FilterProducts.name} | Sort-Object name | Select-Object name, version
-    $toolsetUrl = "https://raw.githubusercontent.com/actions/virtual-environments/main/images/macos/toolsets/toolset-11.json"
+    $toolsetUrl = "https://raw.githubusercontent.com/actions/virtual-environments/main/images/macos/toolsets/toolset-12.json"
     $uploadedReleases = (Invoke-RestMethod $toolsetUrl).xamarin
     $releasesOnImage = @()
     foreach ($FilterProduct in $FilterProducts) {


### PR DESCRIPTION
The new xamarin ios versions support only newer Xcode versions, which are available on macOS-12. We don't want to add new bundles to macOS-11 anymore.