### PR TITLE
Update Xamarin channel link

### DIFF
--- a/get-new-tool-versions/verify-new-tool-version-added-to-image.ps1
+++ b/get-new-tool-versions/verify-new-tool-version-added-to-image.ps1
@@ -22,7 +22,7 @@ if ($ToolName -in "Python", "PyPy", "Node", "Go") {
 }
 
 if ($ToolName -eq "Xamarin") {
-    $xamarinReleases = "http://aka.ms/manifest/stable"
+    $xamarinReleases = "http://aka.ms/manifest/stable-2022"
     $xamarinProducts = @(
         [PSCustomObject] @{name = 'Mono Framework'; property = 'mono-versions'}
         [PSCustomObject] @{name = 'Xamarin.Android'; property = 'android-versions'}


### PR DESCRIPTION
We should use a new channel to parse Xamarin versions - http://aka.ms/manifest/stable-2022