### PR TITLE
Add arm64 packaging on linux and windows for setup-node

### DIFF
--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -35,14 +35,8 @@ jobs:
       fail-fast: false
       matrix:
         platform: [linux, darwin, win32]
-        architecture: [x64]
-        include:
-         - platform: darwin
-            architecture: arm64
-         - platform: linux
-            architecture: arm64
-         - platform: win32
-            architecture: arm64
+        architecture: [x64, arm64]
+        
             
           
     steps:
@@ -116,7 +110,7 @@ jobs:
       working-directory: ${{ runner.temp }}/${{ env.ARTIFACT_NAME }}
 
     - name: Setup Node.js ${{ inputs.tool-version }}
-      if: inputs.tool-name == 'node' || matrix.node == true
+      if: inputs.tool-name == 'node'
       uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.tool-version }}

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -116,7 +116,7 @@ jobs:
       working-directory: ${{ runner.temp }}/${{ env.ARTIFACT_NAME }}
 
     - name: Setup Node.js ${{ inputs.tool-version }}
-      if: inputs.tool-name == 'node' && matrix.node == true
+      if: inputs.tool-name == 'node' || matrix.node == true
       uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.tool-version }}

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -37,8 +37,14 @@ jobs:
         platform: [linux, darwin, win32]
         architecture: [x64]
         include:
-        - architecture: arm64
-          platform: darwin
+         - platform: darwin
+            architecture: arm64
+         - platform: linux
+            architecture: arm64
+         - platform: win32
+            architecture: arm64
+            
+          
     steps:
     - uses: actions/checkout@v3
       with:
@@ -110,7 +116,7 @@ jobs:
       working-directory: ${{ runner.temp }}/${{ env.ARTIFACT_NAME }}
 
     - name: Setup Node.js ${{ inputs.tool-version }}
-      if: inputs.tool-name == 'node'
+      if: inputs.tool-name == 'node' && matrix.node == true
       uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.tool-version }}


### PR DESCRIPTION
This PR will add support to arm64 packaging for Linux and Windows on setup-node along with x64 packaging for all three platforms and arm64 packaging for darwin.