### PR TITLE
workflow update to handle arm64 file formats for windows

### DIFF
--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -93,8 +93,14 @@ jobs:
           } elseif ('${{ inputs.tool-name }}' -eq 'go') {            
             $artifactName = "${{ env.ARTIFACT_NAME }}.zip"
           } else {
+            
+            if ('${{ inputs.tool-name }}' -eq 'node') {
+            $artifactName = "${{ env.ARTIFACT_NAME }}.zip"
+          }else
             Write-Host "Unsupported tool - ${{ inputs.tool-name }}"
             exit 1
+          }
+            
           }
           
           7z.exe x "$artifactName" -y | Out-Null 


### PR DESCRIPTION
This will support the arm64 package files .7z and .zip files based on the supported file from nodejs.org.