### PR TITLE
Fix for windows arm64 node js package (7z) file

### DIFF
--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -28,7 +28,7 @@ defaults:
 jobs:
   build:
     name: Build ${{ inputs.tool-name }} ${{ inputs.tool-version }} [${{ matrix.platform }}] [${{ matrix.architecture }}]
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     env: 
       ARTIFACT_NAME: ${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-${{ matrix.architecture }}
     strategy:

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -25,22 +25,36 @@ defaults:
   run:
     shell: pwsh
 
+# Fix for windows arm64 7z file issue. More details at https://github.com/nodejs/node/issues/52231
 jobs:
   build:
     name: Build ${{ inputs.tool-name }} ${{ inputs.tool-version }} [${{ matrix.platform }}] [${{ matrix.architecture }}]
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     env: 
       ARTIFACT_NAME: ${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-${{ matrix.architecture }}
     strategy:
       fail-fast: false
       matrix:
-        platform: [linux, darwin, win32]
-        architecture: [x64, arm64]
-        
+        include:
+        - os: ubuntu-latest
+          platform: linux
+          architecture: x64
+        - os: ubuntu-latest
+          platform: darwin
+          architecture: x64
+        - os: ubuntu-latest
+          platform: win32
+          architecture: x64
+        - os: ubuntu-latest
+          platform: linux
+          architecture: arm64
+        - os: ubuntu-latest
+          platform: darwin
+          architecture: arm64
             
           
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -49,6 +63,39 @@ jobs:
         ./builders/build-${{ inputs.tool-name }}.ps1 -Version ${{ inputs.tool-version }} `
                                                      -Platform ${{ matrix.platform }} `
                                                      -Architecture ${{ matrix.architecture }}
+
+    - name: Publish artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ runner.temp }}/artifact
+
+  build-arm:
+    name: Build ${{ inputs.tool-name }} ${{ inputs.tool-version }} [${{ matrix.platform }}] [${{ matrix.architecture }}]
+    runs-on: windows-latest
+    if: (inputs.tool-name == 'go') || (inputs.tool-name == 'node' && inputs['tool-version'] > '20.0.0')
+    env: 
+      ARTIFACT_NAME: ${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-${{ matrix.architecture }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:       
+        - os: windows-latest
+          platform: win32
+          architecture: arm64
+            
+          
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Build ${{ inputs.tool-name }} ${{ inputs.tool-version }}
+      run: |
+        ./builders/build-${{ inputs.tool-name }}.ps1 -Version ${{ inputs.tool-version }} `
+                                                     -Platform ${{ matrix.platform }} `
+                                                     -Architecture ${{ matrix.architecture }}
+                                                     
 
     - name: Publish artifact
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
This PR fixes the 7z issue with Windows ARM64 for node versions.
Additional details available at [node](https://github.com/nodejs/node/issues/52231)