### PR TITLE
Architecture update for the test cases of darwin based on macos-14 configuration update

### DIFF
--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -108,17 +108,21 @@ jobs:
     needs: build
     runs-on: ${{ matrix.os }}
     env: 
-      ARTIFACT_NAME: ${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-x64
+      ARTIFACT_NAME: ${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}--${{ matrix.arch }}
     strategy:
       fail-fast: false
       matrix:
         include:
         - os: ubuntu-latest
           platform: linux
-        - os: macos-latest-large
+          arch: x64
+        - os: macos-latest
           platform: darwin
+          arch: arm64
         - os: windows-latest
           platform: win32
+          arch: x64
+
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -115,13 +115,10 @@ jobs:
         include:
         - os: ubuntu-latest
           platform: linux
-          arch: x64
-        - os: macos-latest
+        - os: macos-latest-large
           platform: darwin
-          arch: arm64
         - os: windows-latest
           platform: win32
-          arch: x64
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -115,7 +115,7 @@ jobs:
         include:
         - os: ubuntu-latest
           platform: linux
-        - os: macos-latest-large
+        - os: macos-14-large
           platform: darwin
         - os: windows-latest
           platform: win32

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -108,17 +108,20 @@ jobs:
     needs: build
     runs-on: ${{ matrix.os }}
     env: 
-      ARTIFACT_NAME: ${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-x64
+      ARTIFACT_NAME: ${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-${{ matrix.arch }}
     strategy:
       fail-fast: false
       matrix:
         include:
         - os: ubuntu-latest
           platform: linux
+          arch: x64
         - os: macos-latest
           platform: darwin
+          arch: arm64
         - os: windows-latest
           platform: win32
+          arch: x64
     steps:
     - uses: actions/checkout@v3
       with:
@@ -127,24 +130,10 @@ jobs:
     - name: Fully cleanup the toolcache directory before testing
       run: ./helpers/clean-toolcache.ps1 -ToolName "${{ inputs.tool-name }}"
 
-       
-    - name: Get architecture
-      id: get-arch
-      shell: bash
-      run: |
-        if [[ "${{ matrix.platform }}" == "darwin" ]]; then
-          echo "ARCH=$(uname -m)" >> $GITHUB_ENV
-        else
-          echo "ARCH=x64" >> $GITHUB_ENV
-        fi
-
-    - name: Set env
-      run: echo "ARTIFACT_NAME=${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-$ARCH" >> $GITHUB_ENV
-
-
     - name: Download artifact
       uses: actions/download-artifact@v3
       with:
+        name: ${{ env.ARTIFACT_NAME }}
         path: ${{ runner.temp }}
 
     - name: Extract files

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -115,7 +115,7 @@ jobs:
         include:
         - os: ubuntu-latest
           platform: linux
-        - os: macos-latest
+        - os: macos-latest-large
           platform: darwin
         - os: windows-latest
           platform: win32

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -107,19 +107,19 @@ jobs:
     name: Test ${{ inputs.tool-name }} ${{ inputs.tool-version }} [${{ matrix.platform }}]
     needs: build
     runs-on: ${{ matrix.os }}
-    env: 
-      ARTIFACT_NAME: ${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-x64
     strategy:
-      fail-fast: false
       matrix:
-        include:
-        - os: ubuntu-latest
-          platform: linux
-        - os: macos-14-large
-          platform: darwin
-        - os: windows-latest
-          platform: win32
+        os: [ubuntu-latest, macos-14-large, windows-latest]
+        platform: [linux, darwin, win32]
     steps:
+    - name: Get architecture
+      id: get-arch
+      run: echo "::set-output name=architecture::$(uname -m)"
+      shell: bash
+
+    - name: Build
+      env:
+        ARTIFACT_NAME: ${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-${{ steps.get-arch.outputs.architecture }}
     - uses: actions/checkout@v3
       with:
         submodules: true

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -115,10 +115,13 @@ jobs:
         include:
         - os: ubuntu-latest
           platform: linux
-        - os: macos-latest-large
+          arch: x64
+        - os: macos-latest
           platform: darwin
+          arch: arm64
         - os: windows-latest
           platform: win32
+          arch: x64
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -135,7 +135,18 @@ jobs:
       with:
         name: ${{ env.ARTIFACT_NAME }}
         path: ${{ runner.temp }}
+    - name: Set env
+      run: echo "RUNNER_ARCH=$(uname -m)" >> $GITHUB_ENV
+      shell: bash
 
+    - name: Set ARTIFACT_NAME
+      run: |
+         if [[ "${{ matrix.platform }}" == "darwin" && "${RUNNER_ARCH}" == "arm64" ]]; then
+         echo "ARTIFACT_NAME=${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-arm64" >> $GITHUB_ENV
+         else
+         echo "ARTIFACT_NAME=${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-x64" >> $GITHUB_ENV
+         fi
+      shell: bash
     - name: Extract files
       run: |
         if ('${{ matrix.platform }}' -eq 'win32') {

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -108,17 +108,15 @@ jobs:
     needs: build
     runs-on: ${{ matrix.os }}
     env: 
-      ARTIFACT_NAME: ${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-${{ matrix.arch }}
+      ARTIFACT_NAME: ${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-x64
     strategy:
       fail-fast: false
       matrix:
         include:
         - os: ubuntu-latest
           platform: linux
-          arch: x64
-        - os: macos-latest
+        - os: macos-latest-large
           platform: darwin
-          arch: arm64
         - os: windows-latest
           platform: win32
 

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -108,7 +108,7 @@ jobs:
     needs: build
     runs-on: ${{ matrix.os }}
     env: 
-      ARTIFACT_NAME: ${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}--${{ matrix.arch }}
+      ARTIFACT_NAME: ${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-${{ matrix.arch }}
     strategy:
       fail-fast: false
       matrix:
@@ -122,7 +122,6 @@ jobs:
         - os: windows-latest
           platform: win32
           arch: x64
-
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -145,7 +145,8 @@ jobs:
          echo "ARTIFACT_NAME=${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-arm64" >> $GITHUB_ENV
          else
          echo "ARTIFACT_NAME=${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-x64" >> $GITHUB_ENV
-        
+         fi
+      shell: bash
     - name: Extract files
       run: |
         if ('${{ matrix.platform }}' -eq 'win32') {

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -121,11 +121,11 @@ jobs:
           arch: arm64
         - os: windows-latest
           platform: win32
-          arch: x64
+
     steps:
     - uses: actions/checkout@v3
       with:
-         submodules: true
+        submodules: true
 
     - name: Fully cleanup the toolcache directory before testing
       run: ./helpers/clean-toolcache.ps1 -ToolName "${{ inputs.tool-name }}"
@@ -133,20 +133,8 @@ jobs:
     - name: Download artifact
       uses: actions/download-artifact@v3
       with:
-        name: ${{ env.ARTIFACT_NAME }}
         path: ${{ runner.temp }}
-    - name: Set env
-      run: echo "RUNNER_ARCH=$(uname -m)" >> $GITHUB_ENV
-      
 
-    - name: Set ARTIFACT_NAME
-      shell: pwsh
-      run: |
-       if ("${{ matrix.platform }}" -eq "darwin" -and "${env:RUNNER_ARCH}" -eq "arm64") {
-       echo "ARTIFACT_NAME=${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-arm64" | Out-File -Append -Encoding utf8 -FilePath $env:GITHUB_ENV
-       } else {
-       echo "ARTIFACT_NAME=${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-x64" | Out-File -Append -Encoding utf8 -FilePath $env:GITHUB_ENV
-       }
     - name: Extract files
       run: |
         if ('${{ matrix.platform }}' -eq 'win32') {

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -137,7 +137,7 @@ jobs:
         path: ${{ runner.temp }}
     - name: Set env
       run: echo "RUNNER_ARCH=$(uname -m)" >> $GITHUB_ENV
-      shell: bash
+      
 
     - name: Set ARTIFACT_NAME
       run: |
@@ -145,8 +145,7 @@ jobs:
          echo "ARTIFACT_NAME=${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-arm64" >> $GITHUB_ENV
          else
          echo "ARTIFACT_NAME=${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-x64" >> $GITHUB_ENV
-         fi
-      shell: bash
+        
     - name: Extract files
       run: |
         if ('${{ matrix.platform }}' -eq 'win32') {

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -140,13 +140,13 @@ jobs:
       
 
     - name: Set ARTIFACT_NAME
+      shell: pwsh
       run: |
-         if [[ "${{ matrix.platform }}" == "darwin" && "${RUNNER_ARCH}" == "arm64" ]]; then
-         echo "ARTIFACT_NAME=${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-arm64" >> $GITHUB_ENV
-         else
-         echo "ARTIFACT_NAME=${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-x64" >> $GITHUB_ENV
-         fi
-      shell: bash
+       if ("${{ matrix.platform }}" -eq "darwin" -and "${env:RUNNER_ARCH}" -eq "arm64") {
+       echo "ARTIFACT_NAME=${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-arm64" | Out-File -Append -Encoding utf8 -FilePath $env:GITHUB_ENV
+       } else {
+       echo "ARTIFACT_NAME=${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-x64" | Out-File -Append -Encoding utf8 -FilePath $env:GITHUB_ENV
+       }
     - name: Extract files
       run: |
         if ('${{ matrix.platform }}' -eq 'win32') {

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -107,25 +107,40 @@ jobs:
     name: Test ${{ inputs.tool-name }} ${{ inputs.tool-version }} [${{ matrix.platform }}]
     needs: build
     runs-on: ${{ matrix.os }}
+    env: 
+      ARTIFACT_NAME: ${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-x64
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14-large, windows-latest]
-        platform: [linux, darwin, win32]
+        include:
+        - os: ubuntu-latest
+          platform: linux
+        - os: macos-latest
+          platform: darwin
+        - os: windows-latest
+          platform: win32
     steps:
-    - name: Get architecture
-      id: get-arch
-      run: echo "::set-output name=architecture::$(uname -m)"
-      shell: bash
-
-    - name: Build
-      env:
-        ARTIFACT_NAME: ${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-${{ steps.get-arch.outputs.architecture }}
     - uses: actions/checkout@v3
       with:
-        submodules: true
+         submodules: true
 
     - name: Fully cleanup the toolcache directory before testing
       run: ./helpers/clean-toolcache.ps1 -ToolName "${{ inputs.tool-name }}"
+
+       
+    - name: Get architecture
+      id: get-arch
+      shell: bash
+      run: |
+        if [[ "${{ matrix.platform }}" == "darwin" ]]; then
+          echo "ARCH=$(uname -m)" >> $GITHUB_ENV
+        else
+          echo "ARCH=x64" >> $GITHUB_ENV
+        fi
+
+    - name: Set env
+      run: echo "ARTIFACT_NAME=${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-$ARCH" >> $GITHUB_ENV
+
 
     - name: Download artifact
       uses: actions/download-artifact@v3


### PR DESCRIPTION
This PR will update the artifact name based on the architecture of the platform to pass Tests after the macos-14 configuration changed to arm64 instead of x64.