### PR TITLE
Fix Windows arm64 artifact extraction issue on Ubuntu-latest

### DIFF
--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -30,7 +30,7 @@ jobs:
 
   build:
     name: Build ${{ inputs.tool-name }} ${{ inputs.tool-version }} [${{ matrix.platform }}] [${{ matrix.architecture }}]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env: 
       ARTIFACT_NAME: ${{ inputs.tool-name }}-${{ inputs.tool-version }}-${{ matrix.platform }}-${{ matrix.architecture }}
       excludewinarm: ${{ !(inputs.tool-name == 'node' && inputs['tool-version'] < '20.0.0' && matrix.architecture == 'arm64' && matrix.platform == 'win32') }}


### PR DESCRIPTION
This PR fixes the windows arm64 7z artifact extraction on Ubuntu-24.04