### PR TITLE
Replace self hosted runners with arm runners

### DIFF
--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -82,41 +82,17 @@ jobs:
         - os: windows-latest
           platform: win32
           architecture: x64
-        - os: setup-actions-ubuntu-arm64-2-core
+        - os: ubuntu-22.04-arm
           platform: linux
           architecture: arm64
-          runner_type: self-hosted
         - os: macos-latest
           platform: darwin
           architecture: arm64
-        - os: setup-actions-windows-arm64-4-core
+        - os: windows-11-arm
           platform: win32
           architecture: arm64
-          runner_type: self-hosted
 
-    steps:
-    - name: Setup Environment on Windows ARM64 Runner
-      if: matrix.os == 'setup-actions-windows-arm64-4-core'
-      shell: powershell
-      run: |
-            # Install Chocolatey
-            Set-ExecutionPolicy Bypass -Scope Process -Force
-            [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
-            iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
-            echo "C:\ProgramData\Chocolatey\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-        
-            # Install PowerShell
-            choco install powershell-core -y
-            echo "C:\Program Files\PowerShell\7" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-        
-            # Install Git
-            choco install git -y
-            echo "C:\Program Files\Git\cmd" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-        
-            
-             # Install 7-Zip
-            choco install 7zip -y
-            echo "C:\ProgramData\chocolatey\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+    steps:    
     - name: checkout
       if: env.excludewinarm == 'true'
       uses: actions/checkout@v4


### PR DESCRIPTION
This allows contributors to test on GitHub hosted Linux ARM64 runners easily now that those runners are available for free for public repositories:
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/
https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/