### PR TITLE
Update GitHub Actions to use v4 of actions

### DIFF
--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         platform: [linux, darwin, win32]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -46,7 +46,7 @@ jobs:
                                                      -Platform ${{ matrix.platform }}
 
     - name: Publish artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACT_NAME }}
         path: ${{ runner.temp }}/artifact
@@ -68,7 +68,7 @@ jobs:
         - os: windows-latest
           platform: win32
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -76,7 +76,7 @@ jobs:
       run: ./helpers/clean-toolcache.ps1 -ToolName "${{ inputs.tool-name }}"
 
     - name: Download artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: ${{ runner.temp }}
 
@@ -140,7 +140,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
 
     - name: Generate release body
       id: generate-release-body

--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -24,7 +24,7 @@ jobs:
   validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -37,7 +37,7 @@ jobs:
     needs: [validation]
     if: failure()
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 


### PR DESCRIPTION
Bump actions/checkout, actions/upload-artifact, and actions/download-artifact from v3 to v4 in workflow files for improved performance and support.