### PR TITLE
Replace macos-13 with macos-15-intel

### DIFF
--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -175,10 +175,10 @@ jobs:
         Import-Module Pester
         $toolName = (Get-Culture).TextInfo.ToTitleCase("${{ inputs.tool-name }}")
         Invoke-Pester -Configuration @{
-                  Run = @{ Path = "./$toolName.Tests.ps1" }
-                  Should = @{ ErrorAction = 'Continue' }
-                  Output = @{ EnableExit = $true }
-                }
+            Run = @{ Path = "./$toolName.Tests.ps1" }
+            Should = @{ ErrorAction = 'Continue' }
+            Output = @{ EnableExit = $true }
+        }
       working-directory: ./tests
 
   publish_release:

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -168,7 +168,11 @@ jobs:
         Install-Module Pester -Force -Scope CurrentUser -SkipPublisherCheck
         Import-Module Pester
         $toolName = (Get-Culture).TextInfo.ToTitleCase("${{ inputs.tool-name }}")
-        Invoke-Pester -Script ./$toolName.Tests.ps1 -EnableExit
+        Invoke-Pester -Configuration @{
+                  Run = @{ Path = "./$toolName.Tests.ps1" }
+                  Should = @{ ErrorAction = 'Continue' }
+                  Output = @{ EnableExit = $true }
+                }      
       working-directory: ./tests
 
   publish_release:

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -161,6 +161,7 @@ jobs:
         for ($i = 0; $i -lt 200; $i++) { Get-Random }
 
     - name: Ensure Pester Installed
+      if: env.excludewinarm == 'true'
       run: |
         $module = Get-Module -ListAvailable -Name Pester
         if (-not $module -or ($module.Version -lt [Version]"5.0.0")) {

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -160,9 +160,13 @@ jobs:
         Write-Host "to determine if ${{ inputs.tool-name }} version was consumed from cache or if it was downloaded"
         for ($i = 0; $i -lt 200; $i++) { Get-Random }
 
-    - name: Install Pester
-      run: Install-Module Pester -Force -Scope CurrentUser -SkipPublisherCheck
-
+    - name: Ensure Pester Installed
+      run: |
+        $module = Get-Module -ListAvailable -Name Pester
+        if (-not $module -or ($module.Version -lt [Version]"5.0.0")) {
+          Install-Module Pester -Force -Scope CurrentUser -SkipPublisherCheck
+        }
+        
     - name: Run tests
       if: env.excludewinarm == 'true'
       env:

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -169,7 +169,7 @@ jobs:
         
     - name: Run tests
       if: env.excludewinarm == 'true'
-      env:
+      env: 
         VERSION: ${{ inputs.tool-version }}
       run: |
         Import-Module Pester
@@ -180,21 +180,6 @@ jobs:
                   Output = @{ EnableExit = $true }
                 }
       working-directory: ./tests
-      
-    # - name: Run tests
-    #   if: env.excludewinarm == 'true'
-    #   env: 
-    #     VERSION: ${{ inputs.tool-version }}
-    #   run: |
-    #     Install-Module Pester -Force -Scope CurrentUser -SkipPublisherCheck
-    #     Import-Module Pester
-    #     $toolName = (Get-Culture).TextInfo.ToTitleCase("${{ inputs.tool-name }}")
-    #     Invoke-Pester -Configuration @{
-    #               Run = @{ Path = "./$toolName.Tests.ps1" }
-    #               Should = @{ ErrorAction = 'Continue' }
-    #               Output = @{ EnableExit = $true }
-    #             }      
-    #   working-directory: ./tests
 
   publish_release:
     name: Publish release

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -76,7 +76,7 @@ jobs:
         - os: ubuntu-latest
           platform: linux
           architecture: x64
-        - os: macos-13
+        - os: macos-15-intel
           platform: darwin
           architecture: x64
         - os: windows-latest

--- a/.github/workflows/build-tool-packages.yml
+++ b/.github/workflows/build-tool-packages.yml
@@ -160,20 +160,37 @@ jobs:
         Write-Host "to determine if ${{ inputs.tool-name }} version was consumed from cache or if it was downloaded"
         for ($i = 0; $i -lt 200; $i++) { Get-Random }
 
+    - name: Install Pester
+      run: Install-Module Pester -Force -Scope CurrentUser -SkipPublisherCheck
+
     - name: Run tests
       if: env.excludewinarm == 'true'
-      env: 
+      env:
         VERSION: ${{ inputs.tool-version }}
       run: |
-        Install-Module Pester -Force -Scope CurrentUser -SkipPublisherCheck
         Import-Module Pester
         $toolName = (Get-Culture).TextInfo.ToTitleCase("${{ inputs.tool-name }}")
         Invoke-Pester -Configuration @{
                   Run = @{ Path = "./$toolName.Tests.ps1" }
                   Should = @{ ErrorAction = 'Continue' }
                   Output = @{ EnableExit = $true }
-                }      
+                }
       working-directory: ./tests
+      
+    # - name: Run tests
+    #   if: env.excludewinarm == 'true'
+    #   env: 
+    #     VERSION: ${{ inputs.tool-version }}
+    #   run: |
+    #     Install-Module Pester -Force -Scope CurrentUser -SkipPublisherCheck
+    #     Import-Module Pester
+    #     $toolName = (Get-Culture).TextInfo.ToTitleCase("${{ inputs.tool-name }}")
+    #     Invoke-Pester -Configuration @{
+    #               Run = @{ Path = "./$toolName.Tests.ps1" }
+    #               Should = @{ ErrorAction = 'Continue' }
+    #               Output = @{ EnableExit = $true }
+    #             }      
+    #   working-directory: ./tests
 
   publish_release:
     name: Publish release


### PR DESCRIPTION
`macos-13` will be unsupported by Dec 4th. New x86_64 (Intel) environment is available on `macos-15-intel` runner.
For more info please refer to [runner-images](https://github.com/actions/runner-images/issues/13046)