### PR TITLE
Update version inclusion logic for Node.js parser

### DIFF
--- a/get-new-tool-versions/parsers/node-parser.psm1
+++ b/get-new-tool-versions/parsers/node-parser.psm1
@@ -22,9 +22,16 @@ class NodeVersionsParser: BaseVersionsParser {
         if ($Version.Major -lt 8) {
             return $false
         }
-
-        # For Node.JS, we should include all LTS versions (all even-numbered releases)
-        # https://nodejs.org/en/about/releases/
-        return $Version.Major % 2 -eq 0
+        elseif ($Version.Major -lt 27)
+        {
+            # For Node.JS, we should include all LTS versions (all even-numbered releases)
+            # https://nodejs.org/en/about/releases/
+            return $Version.Major % 2 -eq 0
+        }
+        else
+        {
+            # https://nodejs.org/en/blog/announcements/evolving-the-nodejs-release-schedule
+            return $true
+        }
     }
 }


### PR DESCRIPTION
This PR updates the Node.js parser version inclusion logic to match the newer release schedule - [Reference](https://nodejs.org/en/blog/announcements/evolving-the-nodejs-release-schedule) 

- keep excluding versions earlier than v8
- keep including only even-numbered majors for versions below v27
- include all versions starting from v27

This preserves existing behavior for older releases while allowing newer Node.js versions to be included correctly.
